### PR TITLE
Add sprint page UI

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -44,6 +44,11 @@ def create_app():
     def dashboard():
         return render_template("dashboard.html")
 
+    # Route for sprints page
+    @app.route("/sprints")
+    def sprints():
+        return render_template("sprints.html")
+
     # Route for project page
     @app.route("/project")
     def project():

--- a/app/static/css/dashboard_styles.css
+++ b/app/static/css/dashboard_styles.css
@@ -166,6 +166,12 @@ body {
   height: 100%;
 }
 
+.mini-note,
+.section-subtext {
+  color: #6b7280;
+  font-size: 0.95rem;
+}
+
 .card-label {
   font-size: 0.8rem;
   font-weight: 700;
@@ -366,6 +372,33 @@ body {
 
 .health-list strong {
   color: #111827;
+}
+
+.timeline-list {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.timeline-item {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.timeline-item strong {
+  display: block;
+  margin-bottom: 4px;
+  color: #111827;
+}
+
+.timeline-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: #0f766e;
+  margin-top: 6px;
+  flex-shrink: 0;
 }
 
 @media (max-width: 991.98px) {

--- a/app/static/css/sprints.css
+++ b/app/static/css/sprints.css
@@ -1,0 +1,372 @@
+.sprints-page .sprint-search-box {
+  width: 300px;
+}
+
+.sprints-page .sprint-page-heading {
+  margin-bottom: 18px;
+}
+
+.sprints-page .sprint-overview-section {
+  margin-bottom: 48px;
+}
+
+.sprints-page .sprint-history-section {
+  display: block;
+  width: 100%;
+  clear: both;
+  margin-top: 28px;
+}
+
+.sprints-page .sprint-title {
+  font-size: 1.85rem;
+}
+
+.sprints-page .breadcrumb-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: #94a3b8;
+  font-size: 0.85rem;
+  margin-bottom: 10px;
+}
+
+.sprints-page .breadcrumb-row i {
+  font-size: 0.7rem;
+}
+
+.sprints-page .breadcrumb-current {
+  color: #0f4c5c;
+  font-weight: 600;
+}
+
+.sprints-page .heading-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.sprints-page .heading-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.sprints-page .outline-action-btn,
+.sprints-page .primary-action-btn {
+  border-radius: 10px;
+  padding: 10px 16px;
+  font-weight: 600;
+  font-size: 0.92rem;
+}
+
+.sprints-page .outline-action-btn {
+  background-color: #ffffff;
+  border: 1px solid #d1d5db;
+  color: #0f4c5c;
+}
+
+.sprints-page .primary-action-btn {
+  background-color: #0f4c5c;
+  border: 1px solid #0f4c5c;
+  color: #ffffff;
+}
+
+.sprints-page .outline-action-btn:hover {
+  background-color: #f8fafc;
+  color: #0f4c5c;
+}
+
+.sprints-page .primary-action-btn:hover {
+  background-color: #0b3a46;
+  color: #ffffff;
+}
+
+.sprints-page .sprint-main-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.65fr) minmax(300px, 0.95fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.sprints-page .sprint-main-left,
+.sprints-page .sprint-main-right {
+  min-width: 0;
+}
+
+.sprints-page .metric-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background-color: #d9f3f1;
+  color: #0f4c5c;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 16px;
+  font-size: 1.2rem;
+}
+
+.sprints-page .sprint-goal-card {
+  min-height: 190px;
+  padding: 24px 26px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(248, 250, 252, 0.98)),
+    radial-gradient(circle at bottom right, rgba(15, 76, 92, 0.08), transparent 35%);
+}
+
+.sprints-page .goal-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #0f4c5c;
+  font-weight: 700;
+  font-size: 0.95rem;
+  margin-bottom: 18px;
+}
+
+.sprints-page .goal-text {
+  max-width: 620px;
+  color: #1f2937;
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.sprints-page .sprint-metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+  margin-top: 20px;
+}
+
+.sprints-page .sprint-metric-card {
+  padding: 20px 22px;
+  min-height: 128px;
+}
+
+.sprints-page .sprint-metric-title {
+  font-family: 'Manrope', sans-serif;
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+.sprints-page .sprint-metric-title span {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #6b7280;
+}
+
+.sprints-page .trend-pill {
+  display: inline-block;
+  margin-left: 10px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  background-color: #dff7ef;
+  color: #0f766e;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.sprints-page .sprint-side-stack {
+  display: grid;
+  gap: 18px;
+}
+
+.sprints-page .sprint-side-card {
+  padding: 22px 24px;
+}
+
+.sprints-page .progress-card {
+  min-height: 118px;
+}
+
+.sprints-page .time-card {
+  min-height: 190px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.sprints-page .side-card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.sprints-page .progress-percent {
+  font-family: 'Manrope', sans-serif;
+  font-size: 1.8rem;
+  font-weight: 800;
+  color: #0f4c5c;
+}
+
+.sprints-page .sprint-progress-tight {
+  height: 10px;
+  margin-bottom: 12px;
+}
+
+.sprints-page .time-card-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.sprints-page .time-value {
+  font-family: 'Manrope', sans-serif;
+  font-size: 2.4rem;
+  font-weight: 800;
+  color: #111827;
+}
+
+.sprints-page .time-value span {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #374151;
+}
+
+.sprints-page .time-pill {
+  display: inline-block;
+  padding: 7px 12px;
+  border-radius: 999px;
+  background-color: #f3f4f6;
+  color: #4b5563;
+  font-size: 0.82rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.sprints-page .mini-chart {
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-end;
+  gap: 6px;
+  margin-top: 26px;
+}
+
+.sprints-page .chart-bar {
+  display: inline-block;
+  width: 18px;
+  border-radius: 4px 4px 0 0;
+  background-color: #d9e2e5;
+}
+
+.sprints-page .chart-bar.short {
+  height: 16px;
+}
+
+.sprints-page .chart-bar.medium {
+  height: 22px;
+}
+
+.sprints-page .chart-bar.tall {
+  height: 30px;
+}
+
+.sprints-page .chart-bar.muted {
+  background-color: #e5ecef;
+}
+
+.sprints-page .chart-bar.accent {
+  background-color: #0f4c5c;
+}
+
+.sprints-page .status-badge.completed {
+  background-color: #dff7ef;
+  color: #0f766e;
+}
+
+.sprints-page .sprint-history-card {
+  padding: 20px 24px 12px;
+  position: relative;
+  z-index: 0;
+}
+
+.sprints-page .sprint-history-card .section-heading {
+  margin-bottom: 14px !important;
+}
+
+.sprints-page .sprint-history-table thead th {
+  font-size: 0.72rem;
+  padding-top: 14px;
+  padding-bottom: 14px;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.sprints-page .sprint-history-table tbody td {
+  padding-top: 18px;
+  padding-bottom: 18px;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.sprints-page .success-rate-cell {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.sprints-page .success-rate-cell span {
+  min-width: 48px;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.sprints-page .success-bar {
+  width: 100%;
+  max-width: 140px;
+  height: 6px;
+  border-radius: 999px;
+  background-color: #dbe4e7;
+  overflow: hidden;
+}
+
+.sprints-page .success-bar-fill {
+  height: 100%;
+  background-color: #0f4c5c;
+  border-radius: 999px;
+}
+
+@media (max-width: 1199.98px) {
+  .sprints-page .sprint-main-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .sprints-page .sprint-main-right {
+    max-width: 520px;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .sprints-page .heading-row {
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .sprints-page .sprint-metrics-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .sprints-page .time-card-top {
+    flex-direction: column;
+  }
+
+  .sprints-page .success-rate-cell {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .sprints-page .sprint-search-box {
+    width: 100%;
+  }
+}

--- a/app/templates/components/sidebar.html
+++ b/app/templates/components/sidebar.html
@@ -8,17 +8,16 @@
       </div>
 
       <nav class="nav flex-column sidebar-nav">
-        <!-- Use Flask routes instead of # -->
-        <a href="{{ url_for('dashboard') }}" class="nav-link active">
+        <a href="{{ url_for('dashboard') }}" class="nav-link {% if request.endpoint == 'dashboard' %}active{% endif %}">
           <i class="bi bi-grid-1x2-fill me-2"></i> Dashboard
         </a>
-        <a href="#" class="nav-link">
+        <a href="{{ url_for('sprints') }}" class="nav-link {% if request.endpoint == 'sprints' %}active{% endif %}">
           <i class="bi bi-flag me-2"></i> Sprints
         </a>
-        <a href="#" class="nav-link sub-link">
+        <a href="{{ url_for('sprints') }}#health" class="nav-link sub-link">
           <i class="bi bi-activity me-2"></i> Sprint Health
         </a>
-        <a href="#" class="nav-link">
+        <a href="{{ url_for('project') }}" class="nav-link {% if request.endpoint == 'project' %}active{% endif %}">
           <i class="bi bi-folder me-2"></i> Projects
         </a>
         <a href="#" class="nav-link">

--- a/app/templates/sprints.html
+++ b/app/templates/sprints.html
@@ -1,0 +1,241 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Agile PM Sprints</title>
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
+      rel="stylesheet"
+    />
+
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/dashboard_styles.css') }}"
+    />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/sprints.css') }}"
+    />
+  </head>
+  <body class="sprints-page">
+    <div class="dashboard-wrapper">
+      <div class="container-fluid">
+        <div class="row g-0 flex-lg-nowrap">
+          {% include "components/sidebar.html" %}
+
+          <main class="col-12 col-lg-10 main-content">
+            <header class="topbar d-flex justify-content-between align-items-center">
+              <div class="search-box sprint-search-box">
+                <i class="bi bi-search"></i>
+                <input
+                  type="text"
+                  class="form-control"
+                  placeholder="Search tasks or sprints..."
+                />
+              </div>
+
+              <div class="topbar-right d-flex align-items-center gap-3">
+                <button class="btn primary-action-btn">+ New Sprint</button>
+                <i class="bi bi-bell"></i>
+                <i class="bi bi-gear"></i>
+
+                <div class="profile-box d-flex align-items-center gap-2">
+                  <div>
+                    <p class="profile-name mb-0">Amit</p>
+                    <small class="profile-link">VIEW PROFILE</small>
+                  </div>
+                  <div class="profile-avatar"></div>
+                </div>
+              </div>
+            </header>
+
+            <section class="welcome-section sprint-page-heading">
+              <div class="breadcrumb-row">
+                <span>Projects</span>
+                <i class="bi bi-chevron-right"></i>
+                <span>Quantum ERP</span>
+                <i class="bi bi-chevron-right"></i>
+                <span class="breadcrumb-current">Sprints</span>
+              </div>
+
+              <div class="heading-row">
+                <div>
+                  <h1 class="welcome-title sprint-title mb-0">Active Sprint (Sprint 12)</h1>
+                </div>
+                <div class="heading-actions">
+                  <button class="btn outline-action-btn">+ New Sprint</button>
+                  <button class="btn primary-action-btn">Complete Sprint</button>
+                </div>
+              </div>
+            </section>
+
+            <section class="sprint-main-grid sprint-overview-section">
+              <div class="sprint-main-left">
+                <div class="summary-card sprint-goal-card">
+                  <div class="goal-label">
+                    <i class="bi bi-flag-fill"></i>
+                    <span>Sprint Goal</span>
+                  </div>
+                  <p class="goal-text mb-0">
+                    Finalize core financial engine integration. Complete all
+                    ledger-to-bank API endpoints and stress test concurrent
+                    transaction throughput for the Q3 release.
+                  </p>
+                </div>
+
+                <div class="sprint-metrics-grid">
+                  <div class="summary-card sprint-metric-card">
+                    <div class="metric-icon"><i class="bi bi-graph-up"></i></div>
+                    <p class="card-label mb-2">CURRENT VELOCITY</p>
+                    <h4 class="sprint-metric-title">42.5 pts <span>/ week</span></h4>
+                  </div>
+
+                  <div class="summary-card sprint-metric-card" id="health">
+                    <div class="metric-icon">
+                      <i class="bi bi-bar-chart-line-fill"></i>
+                    </div>
+                    <p class="card-label mb-2">PROJECT VELOCITY TREND</p>
+                    <h4 class="sprint-metric-title">
+                      +12%
+                      <span class="trend-pill">Improving</span>
+                    </h4>
+                  </div>
+                </div>
+              </div>
+
+              <div class="sprint-main-right">
+                <div class="sprint-side-stack">
+                  <div class="summary-card sprint-side-card progress-card">
+                    <div class="side-card-head">
+                      <span class="card-label mb-0">COMPLETION PROGRESS</span>
+                      <strong class="progress-percent">68%</strong>
+                    </div>
+                    <div class="progress sprint-progress sprint-progress-tight">
+                      <div class="progress-bar completed-bar" style="width: 68%"></div>
+                    </div>
+                    <p class="mini-note mb-0">42 of 62 story points completed</p>
+                  </div>
+
+                  <div class="summary-card sprint-side-card time-card">
+                    <div class="time-card-top">
+                      <div>
+                        <p class="card-label mb-2">TIME REMAINING</p>
+                        <h2 class="time-value mb-0">14 <span>Days</span></h2>
+                      </div>
+                      <span class="time-pill">Ends July 24, 2024</span>
+                    </div>
+
+                    <div class="mini-chart" aria-hidden="true">
+                      <span class="chart-bar muted short"></span>
+                      <span class="chart-bar muted medium"></span>
+                      <span class="chart-bar muted short"></span>
+                      <span class="chart-bar muted tall"></span>
+                      <span class="chart-bar accent medium"></span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section class="sprint-history-section">
+              <div class="table-card sprint-history-card">
+                <div class="section-heading d-flex justify-content-between align-items-center mb-3">
+                  <h2 class="section-title mb-0">Past Sprints</h2>
+                  <a href="#" class="section-link">View Historical Reports</a>
+                </div>
+
+                <div class="table-responsive">
+                  <table class="table task-table sprint-history-table mb-0">
+                    <thead>
+                      <tr>
+                        <th>SPRINT NAME</th>
+                        <th>DURATION</th>
+                        <th>STATUS</th>
+                        <th>STORY POINTS</th>
+                        <th>SUCCESS RATE</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td>Sprint 11</td>
+                        <td>Jun 14 - Jun 28</td>
+                        <td><span class="status-badge completed">Completed</span></td>
+                        <td>84 / 88</td>
+                        <td>
+                          <div class="success-rate-cell">
+                            <div class="success-bar">
+                              <div class="success-bar-fill" style="width: 95.4%"></div>
+                            </div>
+                            <span>95.4%</span>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>Sprint 10</td>
+                        <td>May 30 - Jun 13</td>
+                        <td><span class="status-badge completed">Completed</span></td>
+                        <td>92 / 92</td>
+                        <td>
+                          <div class="success-rate-cell">
+                            <div class="success-bar">
+                              <div class="success-bar-fill" style="width: 100%"></div>
+                            </div>
+                            <span>100%</span>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>Sprint 9</td>
+                        <td>May 15 - May 29</td>
+                        <td><span class="status-badge completed">Completed</span></td>
+                        <td>78 / 85</td>
+                        <td>
+                          <div class="success-rate-cell">
+                            <div class="success-bar">
+                              <div class="success-bar-fill" style="width: 91.7%"></div>
+                            </div>
+                            <span>91.7%</span>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>Sprint 8</td>
+                        <td>May 01 - May 14</td>
+                        <td><span class="status-badge completed">Completed</span></td>
+                        <td>85 / 85</td>
+                        <td>
+                          <div class="success-rate-cell">
+                            <div class="success-bar">
+                              <div class="success-bar-fill" style="width: 100%"></div>
+                            </div>
+                            <span>100%</span>
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </section>
+          </main>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
**Description**

This PR adds the sprint page UI.

**What was added**

added a new `/sprints` route in the Flask app
created the `sprints.html` template
added sprint-specific styling in `sprints.css`
updated the sidebar so the Sprints tab links to the new page
kept the sprint page aligned with the existing dashboard structure and styling

**Key files changed**

`app/__init__.py`
`app/templates/components/sidebar.html`
`app/templates/sprints.html`
`app/static/css/dashboard_styles.css`
`app/static/css/sprints.css`