### PR TITLE
Separate common layout components

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{% block title %}Agile PM{% endblock %}</title>
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
+      rel="stylesheet"
+    />
+
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/dashboard_styles.css') }}"
+    />
+    {% block extra_css %}{% endblock %}
+  </head>
+  <body class="{% block body_class %}{% endblock %}">
+    <div class="dashboard-wrapper">
+      <div class="container-fluid">
+        <div class="row g-0 flex-lg-nowrap">
+          {% include "components/sidebar.html" %}
+
+          <main class="col-12 col-lg-10 main-content">
+            {% block content %}{% endblock %}
+          </main>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/app/templates/components/topbar.html
+++ b/app/templates/components/topbar.html
@@ -1,0 +1,34 @@
+<header class="topbar d-flex justify-content-between align-items-center">
+  <div class="d-flex align-items-center gap-4 flex-wrap">
+    {% if topbar_title %}
+    <h3 class="page-title mb-0">{{ topbar_title }}</h3>
+    {% endif %}
+
+    <div class="search-box {{ topbar_search_class | default('') }}">
+      <i class="bi bi-search"></i>
+      <input
+        type="text"
+        class="form-control"
+        placeholder="{{ topbar_search_placeholder | default('Search...') }}"
+      />
+    </div>
+  </div>
+
+  <div class="topbar-right d-flex align-items-center gap-3">
+    {% if topbar_action_label %}
+    <button class="btn {{ topbar_action_class | default('primary-action-btn') }}">
+      {{ topbar_action_label }}
+    </button>
+    {% endif %}
+    <i class="bi bi-bell"></i>
+    <i class="bi bi-gear"></i>
+
+    <div class="profile-box d-flex align-items-center gap-2">
+      <div>
+        <p class="profile-name mb-0">{{ profile_name | default('Amit') }}</p>
+        <small class="profile-link">VIEW PROFILE</small>
+      </div>
+      <div class="profile-avatar"></div>
+    </div>
+  </div>
+</header>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,218 +1,130 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Agile PM Dashboard</title>
+{% extends "base.html" %}
 
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&display=swap"
-      rel="stylesheet"
-    />
+{% block title %}Agile PM Dashboard{% endblock %}
 
-    <!-- Bootstrap 5 -->
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
+{% block content %}
+{% set topbar_title = 'Dashboard' %}
+{% set topbar_search_placeholder = 'Search projects...' %}
+{% include "components/topbar.html" %}
 
-    <!-- Bootstrap Icons -->
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
-      rel="stylesheet"
-    />
+<section class="welcome-section">
+  <h1 class="welcome-title">Welcome back, {{ user.full_name if user else 'User' }}</h1>
+  <p class="welcome-text">
+    Here's the latest overview for your workspace today.
+  </p>
+</section>
 
-    <!-- Dashboard styles served from Flask static folder -->
-    <link
-      rel="stylesheet"
-      href="{{ url_for('static', filename='css/dashboard_styles.css') }}"
-    />
-  </head>
-  <body>
-    <div class="dashboard-wrapper">
-      <div class="container-fluid">
-        <div class="row g-0 flex-lg-nowrap">
-          <!-- Reusable sidebar component using Jinja include -->
-          {% include "components/sidebar.html" %}
+<section class="row g-4 mb-4">
+  <div class="col-lg-8">
+    <div class="summary-card large-card">
+      <p class="card-label">NUMBER OF ACTIVE PROJECTS</p>
+      <h2 class="summary-number">4 <span>Active Projects</span></h2>
+    </div>
+  </div>
 
-          <!-- Main content -->
-          <main class="col-12 col-lg-10 main-content">
-            <!-- Top header -->
-            <header
-              class="topbar d-flex justify-content-between align-items-center"
-            >
-              <div class="d-flex align-items-center gap-4 flex-wrap">
-                <h3 class="page-title mb-0">Dashboard</h3>
+  <div class="col-lg-4">
+    <div class="summary-card velocity-card">
+      <i class="bi bi-speedometer2 velocity-icon"></i>
+      <h2 class="velocity-number">84%</h2>
+      <p class="mb-0">Sprint Velocity</p>
+    </div>
+  </div>
+</section>
 
-                <div class="search-box">
-                  <i class="bi bi-search"></i>
-                  <input
-                    type="text"
-                    class="form-control"
-                    placeholder="Search projects..."
-                  />
-                </div>
-              </div>
+<section class="mb-4">
+  <div class="section-heading d-flex justify-content-between align-items-center mb-3">
+    <h2 class="section-title mb-0">Active Projects</h2>
+    <a href="#" class="section-link">View all projects</a>
+  </div>
 
-              <div class="topbar-right d-flex align-items-center gap-3">
-                <i class="bi bi-bell"></i>
-                <i class="bi bi-gear"></i>
-
-                <div class="profile-box d-flex align-items-center gap-2">
-                  <div>
-                    <p class="profile-name mb-0">Amit</p>
-                    <small class="profile-link">VIEW PROFILE</small>
-                  </div>
-                  <div class="profile-avatar"></div>
-                </div>
-              </div>
-            </header>
-
-            <!-- Welcome section -->
-            <section class="welcome-section">
-              <h1 class="welcome-title">Welcome back, {{ user.full_name if user else 'User' }}</h1>
-              <p class="welcome-text">
-                Here's the latest overview for your workspace today.
-              </p>
-            </section>
-
-            <!-- Stats row -->
-            <section class="row g-4 mb-4">
-              <div class="col-lg-8">
-                <div class="summary-card large-card">
-                  <p class="card-label">NUMBER OF ACTIVE PROJECTS</p>
-                  <h2 class="summary-number">4 <span>Active Projects</span></h2>
-                </div>
-              </div>
-
-              <div class="col-lg-4">
-                <div class="summary-card velocity-card">
-                  <i class="bi bi-speedometer2 velocity-icon"></i>
-                  <h2 class="velocity-number">84%</h2>
-                  <p class="mb-0">Sprint Velocity</p>
-                </div>
-              </div>
-            </section>
-
-            <!-- Active projects -->
-            <section class="mb-4">
-              <div
-                class="section-heading d-flex justify-content-between align-items-center mb-3"
-              >
-                <h2 class="section-title mb-0">Active Projects</h2>
-                <a href="#" class="section-link">View all projects</a>
-              </div>
-
-              <div class="row g-4">
-                {% for project in projects %}
-                <div class="col-md-6 col-xl-3">
-                  <div class="project-card">
-                    <div class="project-icon"><i class="bi bi-laptop"></i></div>
-                    <h5>{{ project.name }}</h5>
-                    <p>{{ project.description or 'No description.' }}</p>
-                    <span class="status-pill {{ 'healthy' if project.health_status == 'healthy' else 'risk' }}">
-                      {{ project.health_status | capitalize }}
-                    </span>
-                  </div>
-                </div>
-                {% endfor %}
-                <div class="col-md-6 col-xl-3">
-                  <div class="project-card new-project-card">
-                    <div class="project-icon"><i class="bi bi-plus-lg"></i></div>
-                    <h5>New Project</h5>
-                    <p>Create a new workspace for your team.</p>
-                  </div>
-                </div>
-              </div>
-            </section>
-
-            <!-- Tasks and sprint health -->
-            <section class="row g-4">
-              <div class="col-lg-8">
-                <div
-                  class="section-heading d-flex justify-content-between align-items-center mb-3"
-                >
-                  <h2 class="section-title mb-0">My Assigned Tasks</h2>
-                  <button class="btn new-task-btn">+ New Task</button>
-                </div>
-
-                <div class="table-card">
-                  <div class="table-responsive">
-                    <table class="table task-table mb-0">
-                      <thead>
-                        <tr>
-                          <th>TASK NAME</th>
-                          <th>PROJECT</th>
-                          <th>DUE DATE</th>
-                          <th>STATUS</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        <tbody>
-                          {% for task in tasks %}
-                          <tr>
-                            <td>{{ task.title }}</td>
-                            <td>{{ task.project.name }}</td>
-                            <td>{{ task.due_date.strftime('%b %d') if task.due_date else 'N/A' }}</td>
-                            <td>
-                              <span class="status-badge {{ task.status | replace('_', '-') }}">
-                                {{ task.status | replace('_', ' ') | title }}
-                              </span>
-                            </td>
-                          </tr>
-                          {% else %}
-                          <tr><td colspan="4" class="text-center text-muted">No tasks assigned.</td></tr>
-                          {% endfor %}
-                        </tbody>
-                    </table>
-                  </div>
-                </div>
-              </div>
-
-              <div class="col-lg-4">
-                <div class="health-card">
-                  <h2 class="section-title">Sprint Health At a Glance</h2>
-                  <div
-                    class="d-flex justify-content-between small text-muted mb-3"
-                  >
-                    <span>Active Sprint 12</span>
-                    <span>4 days left</span>
-                  </div>
-
-                  <div class="progress sprint-progress mb-4">
-                    <div
-                      class="progress-bar completed-bar"
-                      style="width: 60%"
-                    ></div>
-                    <div
-                      class="progress-bar progress-bar-middle"
-                      style="width: 25%"
-                    ></div>
-                    <div
-                      class="progress-bar blocker-bar"
-                      style="width: 15%"
-                    ></div>
-                  </div>
-
-                  <ul class="health-list list-unstyled mb-4">
-                    <li><span>Completed</span><strong>24</strong></li>
-                    <li><span>In Progress</span><strong>08</strong></li>
-                    <li><span>Blockers</span><strong>03</strong></li>
-                  </ul>
-
-                  <button class="btn btn-outline-secondary w-100">
-                    View Detailed Analytics
-                  </button>
-                </div>
-              </div>
-            </section>
-          </main>
-        </div>
+  <div class="row g-4">
+    {% for project in projects %}
+    <div class="col-md-6 col-xl-3">
+      <div class="project-card">
+        <div class="project-icon"><i class="bi bi-laptop"></i></div>
+        <h5>{{ project.name }}</h5>
+        <p>{{ project.description or 'No description.' }}</p>
+        <span class="status-pill {{ 'healthy' if project.health_status == 'healthy' else 'risk' }}">
+          {{ project.health_status | capitalize }}
+        </span>
       </div>
     </div>
-  </body>
-</html>
+    {% endfor %}
+    <div class="col-md-6 col-xl-3">
+      <div class="project-card new-project-card">
+        <div class="project-icon"><i class="bi bi-plus-lg"></i></div>
+        <h5>New Project</h5>
+        <p>Create a new workspace for your team.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="row g-4">
+  <div class="col-lg-8">
+    <div class="section-heading d-flex justify-content-between align-items-center mb-3">
+      <h2 class="section-title mb-0">My Assigned Tasks</h2>
+      <button class="btn new-task-btn">+ New Task</button>
+    </div>
+
+    <div class="table-card">
+      <div class="table-responsive">
+        <table class="table task-table mb-0">
+          <thead>
+            <tr>
+              <th>TASK NAME</th>
+              <th>PROJECT</th>
+              <th>DUE DATE</th>
+              <th>STATUS</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for task in tasks %}
+            <tr>
+              <td>{{ task.title }}</td>
+              <td>{{ task.project.name }}</td>
+              <td>{{ task.due_date.strftime('%b %d') if task.due_date else 'N/A' }}</td>
+              <td>
+                <span class="status-badge {{ task.status | replace('_', '-') }}">
+                  {{ task.status | replace('_', ' ') | title }}
+                </span>
+              </td>
+            </tr>
+            {% else %}
+            <tr>
+              <td colspan="4" class="text-center text-muted">No tasks assigned.</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-lg-4">
+    <div class="health-card">
+      <h2 class="section-title">Sprint Health At a Glance</h2>
+      <div class="d-flex justify-content-between small text-muted mb-3">
+        <span>Active Sprint 12</span>
+        <span>4 days left</span>
+      </div>
+
+      <div class="progress sprint-progress mb-4">
+        <div class="progress-bar completed-bar" style="width: 60%"></div>
+        <div class="progress-bar progress-bar-middle" style="width: 25%"></div>
+        <div class="progress-bar blocker-bar" style="width: 15%"></div>
+      </div>
+
+      <ul class="health-list list-unstyled mb-4">
+        <li><span>Completed</span><strong>24</strong></li>
+        <li><span>In Progress</span><strong>08</strong></li>
+        <li><span>Blockers</span><strong>03</strong></li>
+      </ul>
+
+      <button class="btn btn-outline-secondary w-100">
+        View Detailed Analytics
+      </button>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/app/templates/sprints.html
+++ b/app/templates/sprints.html
@@ -1,241 +1,189 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Agile PM Sprints</title>
+{% extends "base.html" %}
 
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&display=swap"
-      rel="stylesheet"
-    />
+{% block title %}Agile PM Sprints{% endblock %}
 
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
+{% block body_class %}sprints-page{% endblock %}
 
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
-      rel="stylesheet"
-    />
+{% block extra_css %}
+<link
+  rel="stylesheet"
+  href="{{ url_for('static', filename='css/sprints.css') }}"
+/>
+{% endblock %}
 
-    <link
-      rel="stylesheet"
-      href="{{ url_for('static', filename='css/dashboard_styles.css') }}"
-    />
-    <link
-      rel="stylesheet"
-      href="{{ url_for('static', filename='css/sprints.css') }}"
-    />
-  </head>
-  <body class="sprints-page">
-    <div class="dashboard-wrapper">
-      <div class="container-fluid">
-        <div class="row g-0 flex-lg-nowrap">
-          {% include "components/sidebar.html" %}
+{% block content %}
+{% set topbar_search_placeholder = 'Search tasks or sprints...' %}
+{% set topbar_search_class = 'sprint-search-box' %}
+{% set topbar_action_label = '+ New Sprint' %}
+{% set topbar_action_class = 'primary-action-btn' %}
+{% include "components/topbar.html" %}
 
-          <main class="col-12 col-lg-10 main-content">
-            <header class="topbar d-flex justify-content-between align-items-center">
-              <div class="search-box sprint-search-box">
-                <i class="bi bi-search"></i>
-                <input
-                  type="text"
-                  class="form-control"
-                  placeholder="Search tasks or sprints..."
-                />
-              </div>
+<section class="welcome-section sprint-page-heading">
+  <div class="breadcrumb-row">
+    <span>Projects</span>
+    <i class="bi bi-chevron-right"></i>
+    <span>Quantum ERP</span>
+    <i class="bi bi-chevron-right"></i>
+    <span class="breadcrumb-current">Sprints</span>
+  </div>
 
-              <div class="topbar-right d-flex align-items-center gap-3">
-                <button class="btn primary-action-btn">+ New Sprint</button>
-                <i class="bi bi-bell"></i>
-                <i class="bi bi-gear"></i>
+  <div class="heading-row">
+    <div>
+      <h1 class="welcome-title sprint-title mb-0">Active Sprint (Sprint 12)</h1>
+    </div>
+    <div class="heading-actions">
+      <button class="btn outline-action-btn">+ New Sprint</button>
+      <button class="btn primary-action-btn">Complete Sprint</button>
+    </div>
+  </div>
+</section>
 
-                <div class="profile-box d-flex align-items-center gap-2">
-                  <div>
-                    <p class="profile-name mb-0">Amit</p>
-                    <small class="profile-link">VIEW PROFILE</small>
-                  </div>
-                  <div class="profile-avatar"></div>
-                </div>
-              </div>
-            </header>
+<section class="sprint-main-grid sprint-overview-section">
+  <div class="sprint-main-left">
+    <div class="summary-card sprint-goal-card">
+      <div class="goal-label">
+        <i class="bi bi-flag-fill"></i>
+        <span>Sprint Goal</span>
+      </div>
+      <p class="goal-text mb-0">
+        Finalize core financial engine integration. Complete all
+        ledger-to-bank API endpoints and stress test concurrent
+        transaction throughput for the Q3 release.
+      </p>
+    </div>
 
-            <section class="welcome-section sprint-page-heading">
-              <div class="breadcrumb-row">
-                <span>Projects</span>
-                <i class="bi bi-chevron-right"></i>
-                <span>Quantum ERP</span>
-                <i class="bi bi-chevron-right"></i>
-                <span class="breadcrumb-current">Sprints</span>
-              </div>
+    <div class="sprint-metrics-grid">
+      <div class="summary-card sprint-metric-card">
+        <div class="metric-icon"><i class="bi bi-graph-up"></i></div>
+        <p class="card-label mb-2">CURRENT VELOCITY</p>
+        <h4 class="sprint-metric-title">42.5 pts <span>/ week</span></h4>
+      </div>
 
-              <div class="heading-row">
-                <div>
-                  <h1 class="welcome-title sprint-title mb-0">Active Sprint (Sprint 12)</h1>
-                </div>
-                <div class="heading-actions">
-                  <button class="btn outline-action-btn">+ New Sprint</button>
-                  <button class="btn primary-action-btn">Complete Sprint</button>
-                </div>
-              </div>
-            </section>
+      <div class="summary-card sprint-metric-card" id="health">
+        <div class="metric-icon">
+          <i class="bi bi-bar-chart-line-fill"></i>
+        </div>
+        <p class="card-label mb-2">PROJECT VELOCITY TREND</p>
+        <h4 class="sprint-metric-title">
+          +12%
+          <span class="trend-pill">Improving</span>
+        </h4>
+      </div>
+    </div>
+  </div>
 
-            <section class="sprint-main-grid sprint-overview-section">
-              <div class="sprint-main-left">
-                <div class="summary-card sprint-goal-card">
-                  <div class="goal-label">
-                    <i class="bi bi-flag-fill"></i>
-                    <span>Sprint Goal</span>
-                  </div>
-                  <p class="goal-text mb-0">
-                    Finalize core financial engine integration. Complete all
-                    ledger-to-bank API endpoints and stress test concurrent
-                    transaction throughput for the Q3 release.
-                  </p>
-                </div>
+  <div class="sprint-main-right">
+    <div class="sprint-side-stack">
+      <div class="summary-card sprint-side-card progress-card">
+        <div class="side-card-head">
+          <span class="card-label mb-0">COMPLETION PROGRESS</span>
+          <strong class="progress-percent">68%</strong>
+        </div>
+        <div class="progress sprint-progress sprint-progress-tight">
+          <div class="progress-bar completed-bar" style="width: 68%"></div>
+        </div>
+        <p class="mini-note mb-0">42 of 62 story points completed</p>
+      </div>
 
-                <div class="sprint-metrics-grid">
-                  <div class="summary-card sprint-metric-card">
-                    <div class="metric-icon"><i class="bi bi-graph-up"></i></div>
-                    <p class="card-label mb-2">CURRENT VELOCITY</p>
-                    <h4 class="sprint-metric-title">42.5 pts <span>/ week</span></h4>
-                  </div>
+      <div class="summary-card sprint-side-card time-card">
+        <div class="time-card-top">
+          <div>
+            <p class="card-label mb-2">TIME REMAINING</p>
+            <h2 class="time-value mb-0">14 <span>Days</span></h2>
+          </div>
+          <span class="time-pill">Ends July 24, 2024</span>
+        </div>
 
-                  <div class="summary-card sprint-metric-card" id="health">
-                    <div class="metric-icon">
-                      <i class="bi bi-bar-chart-line-fill"></i>
-                    </div>
-                    <p class="card-label mb-2">PROJECT VELOCITY TREND</p>
-                    <h4 class="sprint-metric-title">
-                      +12%
-                      <span class="trend-pill">Improving</span>
-                    </h4>
-                  </div>
-                </div>
-              </div>
-
-              <div class="sprint-main-right">
-                <div class="sprint-side-stack">
-                  <div class="summary-card sprint-side-card progress-card">
-                    <div class="side-card-head">
-                      <span class="card-label mb-0">COMPLETION PROGRESS</span>
-                      <strong class="progress-percent">68%</strong>
-                    </div>
-                    <div class="progress sprint-progress sprint-progress-tight">
-                      <div class="progress-bar completed-bar" style="width: 68%"></div>
-                    </div>
-                    <p class="mini-note mb-0">42 of 62 story points completed</p>
-                  </div>
-
-                  <div class="summary-card sprint-side-card time-card">
-                    <div class="time-card-top">
-                      <div>
-                        <p class="card-label mb-2">TIME REMAINING</p>
-                        <h2 class="time-value mb-0">14 <span>Days</span></h2>
-                      </div>
-                      <span class="time-pill">Ends July 24, 2024</span>
-                    </div>
-
-                    <div class="mini-chart" aria-hidden="true">
-                      <span class="chart-bar muted short"></span>
-                      <span class="chart-bar muted medium"></span>
-                      <span class="chart-bar muted short"></span>
-                      <span class="chart-bar muted tall"></span>
-                      <span class="chart-bar accent medium"></span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </section>
-
-            <section class="sprint-history-section">
-              <div class="table-card sprint-history-card">
-                <div class="section-heading d-flex justify-content-between align-items-center mb-3">
-                  <h2 class="section-title mb-0">Past Sprints</h2>
-                  <a href="#" class="section-link">View Historical Reports</a>
-                </div>
-
-                <div class="table-responsive">
-                  <table class="table task-table sprint-history-table mb-0">
-                    <thead>
-                      <tr>
-                        <th>SPRINT NAME</th>
-                        <th>DURATION</th>
-                        <th>STATUS</th>
-                        <th>STORY POINTS</th>
-                        <th>SUCCESS RATE</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td>Sprint 11</td>
-                        <td>Jun 14 - Jun 28</td>
-                        <td><span class="status-badge completed">Completed</span></td>
-                        <td>84 / 88</td>
-                        <td>
-                          <div class="success-rate-cell">
-                            <div class="success-bar">
-                              <div class="success-bar-fill" style="width: 95.4%"></div>
-                            </div>
-                            <span>95.4%</span>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr>
-                        <td>Sprint 10</td>
-                        <td>May 30 - Jun 13</td>
-                        <td><span class="status-badge completed">Completed</span></td>
-                        <td>92 / 92</td>
-                        <td>
-                          <div class="success-rate-cell">
-                            <div class="success-bar">
-                              <div class="success-bar-fill" style="width: 100%"></div>
-                            </div>
-                            <span>100%</span>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr>
-                        <td>Sprint 9</td>
-                        <td>May 15 - May 29</td>
-                        <td><span class="status-badge completed">Completed</span></td>
-                        <td>78 / 85</td>
-                        <td>
-                          <div class="success-rate-cell">
-                            <div class="success-bar">
-                              <div class="success-bar-fill" style="width: 91.7%"></div>
-                            </div>
-                            <span>91.7%</span>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr>
-                        <td>Sprint 8</td>
-                        <td>May 01 - May 14</td>
-                        <td><span class="status-badge completed">Completed</span></td>
-                        <td>85 / 85</td>
-                        <td>
-                          <div class="success-rate-cell">
-                            <div class="success-bar">
-                              <div class="success-bar-fill" style="width: 100%"></div>
-                            </div>
-                            <span>100%</span>
-                          </div>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            </section>
-          </main>
+        <div class="mini-chart" aria-hidden="true">
+          <span class="chart-bar muted short"></span>
+          <span class="chart-bar muted medium"></span>
+          <span class="chart-bar muted short"></span>
+          <span class="chart-bar muted tall"></span>
+          <span class="chart-bar accent medium"></span>
         </div>
       </div>
     </div>
-  </body>
-</html>
+  </div>
+</section>
+
+<section class="sprint-history-section">
+  <div class="table-card sprint-history-card">
+    <div class="section-heading d-flex justify-content-between align-items-center mb-3">
+      <h2 class="section-title mb-0">Past Sprints</h2>
+      <a href="#" class="section-link">View Historical Reports</a>
+    </div>
+
+    <div class="table-responsive">
+      <table class="table task-table sprint-history-table mb-0">
+        <thead>
+          <tr>
+            <th>SPRINT NAME</th>
+            <th>DURATION</th>
+            <th>STATUS</th>
+            <th>STORY POINTS</th>
+            <th>SUCCESS RATE</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Sprint 11</td>
+            <td>Jun 14 - Jun 28</td>
+            <td><span class="status-badge completed">Completed</span></td>
+            <td>84 / 88</td>
+            <td>
+              <div class="success-rate-cell">
+                <div class="success-bar">
+                  <div class="success-bar-fill" style="width: 95.4%"></div>
+                </div>
+                <span>95.4%</span>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td>Sprint 10</td>
+            <td>May 30 - Jun 13</td>
+            <td><span class="status-badge completed">Completed</span></td>
+            <td>92 / 92</td>
+            <td>
+              <div class="success-rate-cell">
+                <div class="success-bar">
+                  <div class="success-bar-fill" style="width: 100%"></div>
+                </div>
+                <span>100%</span>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td>Sprint 9</td>
+            <td>May 15 - May 29</td>
+            <td><span class="status-badge completed">Completed</span></td>
+            <td>78 / 85</td>
+            <td>
+              <div class="success-rate-cell">
+                <div class="success-bar">
+                  <div class="success-bar-fill" style="width: 91.7%"></div>
+                </div>
+                <span>91.7%</span>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td>Sprint 8</td>
+            <td>May 01 - May 14</td>
+            <td><span class="status-badge completed">Completed</span></td>
+            <td>85 / 85</td>
+            <td>
+              <div class="success-rate-cell">
+                <div class="success-bar">
+                  <div class="success-bar-fill" style="width: 100%"></div>
+                </div>
+                <span>100%</span>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
**Description**

This PR separates the shared dashboard layout components so they can be reused across multiple pages.

**What was added**

created a shared `base.html` layout for common page structure
created a reusable `topbar.html` component
updated the dashboard page to extend the shared layout
updated the sprints page to extend the shared layout
kept the existing sidebar component reused through the base layout
cleaned up the dashboard task table markup while refactoring

**Key files changed**

`app/templates/base.html`
`app/templates/components/topbar.html`
`app/templates/dashboard.html`
`app/templates/sprints.html`
