### PR TITLE
Add sprints page functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,9 @@ venv/
 # OS files
 .DS_Store
 Thumbs.db
+server-*.log
 
 # db files
 agilepm.db
 *.db
+*.db-journal

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ server-*.log
 agilepm.db
 *.db
 *.db-journal
+
+# Uploaded profile images
+app/static/uploads/*
+!app/static/uploads/.gitkeep

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -204,7 +204,68 @@ def create_app():
         if g.user is None:
             return redirect(url_for("auth", mode="login"))
 
-        return render_template("sprints.html")
+        # Load the current sprint and previous completed sprints for this page.
+        active_sprint = Sprint.query.filter_by(status="active").order_by(Sprint.end_date.asc()).first()
+        completed_sprints = Sprint.query.filter_by(status="completed").order_by(Sprint.end_date.desc()).all()
+
+        def progress_percent(completed_points, total_points):
+            return round((completed_points / total_points) * 100, 1) if total_points else 0
+
+        current_sprint = {
+            "project_name": "No project selected",
+            "title": "No Active Sprint",
+            "goal": "No active sprint has been created yet.",
+            "velocity": "0 pts",
+            "status": "Not Started",
+            "progress": 0,
+            "story_points": "0 of 0 story points completed",
+            "days_left": 0,
+            "day_label": "Days",
+            "end_label": "No end date",
+        }
+
+        if active_sprint:
+            days_left = max((active_sprint.end_date - date.today()).days, 0)
+            progress = progress_percent(
+                active_sprint.completed_story_points,
+                active_sprint.total_story_points,
+            )
+            current_sprint = {
+                "project_name": active_sprint.project.name,
+                "title": f"Active Sprint ({active_sprint.name})",
+                "goal": active_sprint.goal or "No sprint goal has been added yet.",
+                "velocity": f"{active_sprint.velocity_points} pts",
+                "status": active_sprint.status.replace("_", " ").title(),
+                "progress": progress,
+                "story_points": (
+                    f"{active_sprint.completed_story_points} of "
+                    f"{active_sprint.total_story_points} story points completed"
+                ),
+                "days_left": days_left,
+                "day_label": "Day" if days_left == 1 else "Days",
+                "end_label": active_sprint.end_date.strftime("Ends %b %d, %Y"),
+            }
+
+        # Build simple rows for the past sprint table.
+        past_sprints = []
+        for sprint in completed_sprints:
+            success_rate = progress_percent(
+                sprint.completed_story_points,
+                sprint.total_story_points,
+            )
+            past_sprints.append({
+                "name": sprint.name,
+                "duration": f"{sprint.start_date.strftime('%b %d')} - {sprint.end_date.strftime('%b %d')}",
+                "status": sprint.status.replace("_", " ").title(),
+                "story_points": f"{sprint.completed_story_points} / {sprint.total_story_points}",
+                "success_rate": success_rate,
+            })
+
+        return render_template(
+            "sprints.html",
+            current_sprint=current_sprint,
+            past_sprints=past_sprints,
+        )
 
     # Route for project page
     @app.route("/project")

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -307,6 +307,7 @@ def create_app():
         upcoming_sprints = []
         for sprint in planned_sprints:
             upcoming_sprints.append({
+                "id": sprint.id,
                 "name": sprint.name,
                 "project_name": sprint.project.name,
                 "duration": f"{sprint.start_date.strftime('%b %d')} - {sprint.end_date.strftime('%b %d')}",
@@ -338,6 +339,23 @@ def create_app():
             sprint_errors=sprint_errors,
             form_data=form_data,
         )
+
+    @app.route("/sprints/<int:sprint_id>/activate", methods=["POST"])
+    def activate_sprint(sprint_id):
+        if g.user is None:
+            return redirect(url_for("auth", mode="login"))
+
+        sprint = db.session.get(Sprint, sprint_id)
+        if sprint and sprint.status == "planned":
+            # Keep only one active sprint at a time for the demo workflow.
+            active_sprints = Sprint.query.filter_by(status="active").all()
+            for active in active_sprints:
+                active.status = "planned"
+
+            sprint.status = "active"
+            db.session.commit()
+
+        return redirect(url_for("sprints"))
 
     # Route for project page
     @app.route("/project")

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -269,6 +269,7 @@ def create_app():
             return round((completed_points / total_points) * 100, 1) if total_points else 0
 
         current_sprint = {
+            "id": None,
             "project_name": "No project selected",
             "title": "No Active Sprint",
             "goal": "No active sprint has been created yet.",
@@ -288,6 +289,7 @@ def create_app():
                 active_sprint.total_story_points,
             )
             current_sprint = {
+                "id": active_sprint.id,
                 "project_name": active_sprint.project.name,
                 "title": f"Active Sprint ({active_sprint.name})",
                 "goal": active_sprint.goal or "No sprint goal has been added yet.",
@@ -353,6 +355,24 @@ def create_app():
                 active.status = "planned"
 
             sprint.status = "active"
+            db.session.commit()
+
+        return redirect(url_for("sprints"))
+
+    @app.route("/sprints/<int:sprint_id>/complete", methods=["POST"])
+    def complete_sprint(sprint_id):
+        if g.user is None:
+            return redirect(url_for("auth", mode="login"))
+
+        sprint = db.session.get(Sprint, sprint_id)
+        if sprint and sprint.status == "active":
+            # Use completed task points when possible before closing the sprint.
+            completed_points = sum(
+                task.story_points for task in sprint.tasks if task.status == "done"
+            )
+            if completed_points:
+                sprint.completed_story_points = completed_points
+            sprint.status = "completed"
             db.session.commit()
 
         return redirect(url_for("sprints"))

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -199,13 +199,70 @@ def create_app():
         )
 
     # Route for sprints page
-    @app.route("/sprints")
+    @app.route("/sprints", methods=["GET", "POST"])
     def sprints():
         if g.user is None:
             return redirect(url_for("auth", mode="login"))
 
+        sprint_errors = []
+        form_data = {}
+        projects = Project.query.filter_by(status="active").order_by(Project.name.asc()).all()
+
+        if request.method == "POST":
+            form_data = request.form
+            name = request.form.get("name", "").strip()
+            project_id = request.form.get("project_id")
+            goal = request.form.get("goal", "").strip()
+            start_date_raw = request.form.get("start_date", "")
+            end_date_raw = request.form.get("end_date", "")
+            total_points_raw = request.form.get("total_story_points", "0")
+
+            # Validate the modal form before adding a sprint to the database.
+            project = db.session.get(Project, int(project_id)) if project_id and project_id.isdigit() else None
+            if not project:
+                sprint_errors.append("Please select a project.")
+            if not name:
+                sprint_errors.append("Sprint name is required.")
+
+            try:
+                start_date = date.fromisoformat(start_date_raw)
+                end_date = date.fromisoformat(end_date_raw)
+            except ValueError:
+                start_date = None
+                end_date = None
+                sprint_errors.append("Please enter valid start and end dates.")
+
+            try:
+                total_story_points = int(total_points_raw)
+            except ValueError:
+                total_story_points = 0
+                sprint_errors.append("Story points must be a number.")
+
+            if start_date and end_date and end_date < start_date:
+                sprint_errors.append("End date must be after the start date.")
+
+            if total_story_points < 0:
+                sprint_errors.append("Story points cannot be negative.")
+
+            if not sprint_errors:
+                sprint = Sprint(
+                    project_id=project.id,
+                    name=name,
+                    goal=goal,
+                    status="planned",
+                    start_date=start_date,
+                    end_date=end_date,
+                    total_story_points=total_story_points,
+                    completed_story_points=0,
+                    velocity_points=0,
+                )
+                db.session.add(sprint)
+                db.session.commit()
+                return redirect(url_for("sprints"))
+
         # Load the current sprint and previous completed sprints for this page.
         active_sprint = Sprint.query.filter_by(status="active").order_by(Sprint.end_date.asc()).first()
+        planned_sprints = Sprint.query.filter_by(status="planned").order_by(Sprint.start_date.asc()).all()
         completed_sprints = Sprint.query.filter_by(status="completed").order_by(Sprint.end_date.desc()).all()
 
         def progress_percent(completed_points, total_points):
@@ -246,6 +303,17 @@ def create_app():
                 "end_label": active_sprint.end_date.strftime("Ends %b %d, %Y"),
             }
 
+        # Planned sprints are shown separately so newly created sprints are easy to find.
+        upcoming_sprints = []
+        for sprint in planned_sprints:
+            upcoming_sprints.append({
+                "name": sprint.name,
+                "project_name": sprint.project.name,
+                "duration": f"{sprint.start_date.strftime('%b %d')} - {sprint.end_date.strftime('%b %d')}",
+                "story_points": sprint.total_story_points,
+                "status": sprint.status.title(),
+            })
+
         # Build simple rows for the past sprint table.
         past_sprints = []
         for sprint in completed_sprints:
@@ -264,7 +332,11 @@ def create_app():
         return render_template(
             "sprints.html",
             current_sprint=current_sprint,
+            upcoming_sprints=upcoming_sprints,
             past_sprints=past_sprints,
+            projects=projects,
+            sprint_errors=sprint_errors,
+            form_data=form_data,
         )
 
     # Route for project page

--- a/app/templates/components/topbar.html
+++ b/app/templates/components/topbar.html
@@ -16,7 +16,14 @@
 
   <div class="topbar-right d-flex align-items-center gap-3">
     {% if topbar_action_label %}
-    <button class="btn {{ topbar_action_class | default('primary-action-btn') }}">
+    <button
+      class="btn {{ topbar_action_class | default('primary-action-btn') }}"
+      {% if topbar_action_modal_id %}
+      type="button"
+      data-bs-toggle="modal"
+      data-bs-target="#{{ topbar_action_modal_id }}"
+      {% endif %}
+    >
       {{ topbar_action_label }}
     </button>
     {% endif %}

--- a/app/templates/sprints.html
+++ b/app/templates/sprints.html
@@ -53,7 +53,11 @@
       >
         + New Sprint
       </button>
-      <button class="btn primary-action-btn">Complete Sprint</button>
+      {% if current_sprint.id %}
+      <form method="POST" action="{{ url_for('complete_sprint', sprint_id=current_sprint.id) }}">
+        <button type="submit" class="btn primary-action-btn">Complete Sprint</button>
+      </form>
+      {% endif %}
     </div>
   </div>
 </section>

--- a/app/templates/sprints.html
+++ b/app/templates/sprints.html
@@ -17,9 +17,21 @@
 {% set topbar_search_class = 'sprint-search-box' %}
 {% set topbar_action_label = '+ New Sprint' %}
 {% set topbar_action_class = 'primary-action-btn' %}
+{% set topbar_action_modal_id = 'newSprintModal' %}
 {% include "components/topbar.html" %}
 
 <section class="welcome-section sprint-page-heading">
+  {% if sprint_errors %}
+  <div class="alert alert-danger" role="alert">
+    <strong>Could not create sprint.</strong>
+    <ul class="mb-0 mt-2">
+      {% for error in sprint_errors %}
+      <li>{{ error }}</li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
+
   <div class="breadcrumb-row">
     <span>Projects</span>
     <i class="bi bi-chevron-right"></i>
@@ -33,7 +45,14 @@
       <h1 class="welcome-title sprint-title mb-0">{{ current_sprint.title }}</h1>
     </div>
     <div class="heading-actions">
-      <button class="btn outline-action-btn">+ New Sprint</button>
+      <button
+        class="btn outline-action-btn"
+        type="button"
+        data-bs-toggle="modal"
+        data-bs-target="#newSprintModal"
+      >
+        + New Sprint
+      </button>
       <button class="btn primary-action-btn">Complete Sprint</button>
     </div>
   </div>
@@ -108,6 +127,43 @@
 <section class="sprint-history-section">
   <div class="table-card sprint-history-card">
     <div class="section-heading d-flex justify-content-between align-items-center mb-3">
+      <h2 class="section-title mb-0">Planned Sprints</h2>
+    </div>
+
+    <div class="table-responsive">
+      <table class="table task-table sprint-history-table mb-0">
+        <thead>
+          <tr>
+            <th>SPRINT NAME</th>
+            <th>PROJECT</th>
+            <th>DURATION</th>
+            <th>STORY POINTS</th>
+            <th>STATUS</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for sprint in upcoming_sprints %}
+          <tr>
+            <td>{{ sprint.name }}</td>
+            <td>{{ sprint.project_name }}</td>
+            <td>{{ sprint.duration }}</td>
+            <td>{{ sprint.story_points }}</td>
+            <td><span class="status-badge todo">{{ sprint.status }}</span></td>
+          </tr>
+          {% else %}
+          <tr>
+            <td colspan="5" class="text-center text-muted">No planned sprints yet.</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<section class="sprint-history-section">
+  <div class="table-card sprint-history-card">
+    <div class="section-heading d-flex justify-content-between align-items-center mb-3">
       <h2 class="section-title mb-0">Past Sprints</h2>
       <a href="#" class="section-link">View Historical Reports</a>
     </div>
@@ -149,4 +205,99 @@
     </div>
   </div>
 </section>
+
+<div class="modal fade" id="newSprintModal" tabindex="-1" aria-labelledby="newSprintModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered">
+    <div class="modal-content">
+      <form method="POST" action="{{ url_for('sprints') }}">
+        <div class="modal-header">
+          <h5 class="modal-title fw-bold" id="newSprintModalLabel">Create New Sprint</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+
+        <div class="modal-body">
+          <div class="row g-3">
+            <div class="col-md-6">
+              <label class="form-label fw-semibold" for="project_id">Project</label>
+              <select class="form-select" id="project_id" name="project_id" required>
+                <option value="">Select project</option>
+                {% for project in projects %}
+                <option
+                  value="{{ project.id }}"
+                  {% if form_data.get('project_id') == project.id|string %}selected{% endif %}
+                >
+                  {{ project.name }}
+                </option>
+                {% endfor %}
+              </select>
+            </div>
+
+            <div class="col-md-6">
+              <label class="form-label fw-semibold" for="name">Sprint Name</label>
+              <input
+                type="text"
+                class="form-control"
+                id="name"
+                name="name"
+                value="{{ form_data.get('name', '') }}"
+                required
+              />
+            </div>
+
+            <div class="col-md-6">
+              <label class="form-label fw-semibold" for="start_date">Start Date</label>
+              <input
+                type="date"
+                class="form-control"
+                id="start_date"
+                name="start_date"
+                value="{{ form_data.get('start_date', '') }}"
+                required
+              />
+            </div>
+
+            <div class="col-md-6">
+              <label class="form-label fw-semibold" for="end_date">End Date</label>
+              <input
+                type="date"
+                class="form-control"
+                id="end_date"
+                name="end_date"
+                value="{{ form_data.get('end_date', '') }}"
+                required
+              />
+            </div>
+
+            <div class="col-md-6">
+              <label class="form-label fw-semibold" for="total_story_points">Total Story Points</label>
+              <input
+                type="number"
+                class="form-control"
+                id="total_story_points"
+                name="total_story_points"
+                min="0"
+                value="{{ form_data.get('total_story_points', 0) }}"
+              />
+            </div>
+
+            <div class="col-12">
+              <label class="form-label fw-semibold" for="goal">Sprint Goal</label>
+              <textarea
+                class="form-control"
+                id="goal"
+                name="goal"
+                rows="3"
+              >{{ form_data.get('goal', '') }}</textarea>
+            </div>
+          </div>
+        </div>
+
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn primary-action-btn">Save Sprint</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/app/templates/sprints.html
+++ b/app/templates/sprints.html
@@ -12,6 +12,7 @@
 {% endblock %}
 
 {% block content %}
+{% set topbar_title = 'Sprints' %}
 {% set topbar_search_placeholder = 'Search tasks or sprints...' %}
 {% set topbar_search_class = 'sprint-search-box' %}
 {% set topbar_action_label = '+ New Sprint' %}
@@ -22,14 +23,14 @@
   <div class="breadcrumb-row">
     <span>Projects</span>
     <i class="bi bi-chevron-right"></i>
-    <span>Quantum ERP</span>
+    <span>{{ current_sprint.project_name }}</span>
     <i class="bi bi-chevron-right"></i>
     <span class="breadcrumb-current">Sprints</span>
   </div>
 
   <div class="heading-row">
     <div>
-      <h1 class="welcome-title sprint-title mb-0">Active Sprint (Sprint 12)</h1>
+      <h1 class="welcome-title sprint-title mb-0">{{ current_sprint.title }}</h1>
     </div>
     <div class="heading-actions">
       <button class="btn outline-action-btn">+ New Sprint</button>
@@ -46,9 +47,7 @@
         <span>Sprint Goal</span>
       </div>
       <p class="goal-text mb-0">
-        Finalize core financial engine integration. Complete all
-        ledger-to-bank API endpoints and stress test concurrent
-        transaction throughput for the Q3 release.
+        {{ current_sprint.goal }}
       </p>
     </div>
 
@@ -56,17 +55,17 @@
       <div class="summary-card sprint-metric-card">
         <div class="metric-icon"><i class="bi bi-graph-up"></i></div>
         <p class="card-label mb-2">CURRENT VELOCITY</p>
-        <h4 class="sprint-metric-title">42.5 pts <span>/ week</span></h4>
+        <h4 class="sprint-metric-title">{{ current_sprint.velocity }} <span>/ sprint</span></h4>
       </div>
 
       <div class="summary-card sprint-metric-card" id="health">
         <div class="metric-icon">
           <i class="bi bi-bar-chart-line-fill"></i>
         </div>
-        <p class="card-label mb-2">PROJECT VELOCITY TREND</p>
+        <p class="card-label mb-2">SPRINT STATUS</p>
         <h4 class="sprint-metric-title">
-          +12%
-          <span class="trend-pill">Improving</span>
+          {{ current_sprint.status }}
+          <span class="trend-pill">{{ current_sprint.progress }}%</span>
         </h4>
       </div>
     </div>
@@ -77,21 +76,21 @@
       <div class="summary-card sprint-side-card progress-card">
         <div class="side-card-head">
           <span class="card-label mb-0">COMPLETION PROGRESS</span>
-          <strong class="progress-percent">68%</strong>
+          <strong class="progress-percent">{{ current_sprint.progress }}%</strong>
         </div>
         <div class="progress sprint-progress sprint-progress-tight">
-          <div class="progress-bar completed-bar" style="width: 68%"></div>
+          <div class="progress-bar completed-bar" style="width: {{ current_sprint.progress }}%"></div>
         </div>
-        <p class="mini-note mb-0">42 of 62 story points completed</p>
+        <p class="mini-note mb-0">{{ current_sprint.story_points }}</p>
       </div>
 
       <div class="summary-card sprint-side-card time-card">
         <div class="time-card-top">
           <div>
             <p class="card-label mb-2">TIME REMAINING</p>
-            <h2 class="time-value mb-0">14 <span>Days</span></h2>
+            <h2 class="time-value mb-0">{{ current_sprint.days_left }} <span>{{ current_sprint.day_label }}</span></h2>
           </div>
-          <span class="time-pill">Ends July 24, 2024</span>
+          <span class="time-pill">{{ current_sprint.end_label }}</span>
         </div>
 
         <div class="mini-chart" aria-hidden="true">
@@ -125,62 +124,26 @@
           </tr>
         </thead>
         <tbody>
+          {% for sprint in past_sprints %}
           <tr>
-            <td>Sprint 11</td>
-            <td>Jun 14 - Jun 28</td>
-            <td><span class="status-badge completed">Completed</span></td>
-            <td>84 / 88</td>
+            <td>{{ sprint.name }}</td>
+            <td>{{ sprint.duration }}</td>
+            <td><span class="status-badge completed">{{ sprint.status }}</span></td>
+            <td>{{ sprint.story_points }}</td>
             <td>
               <div class="success-rate-cell">
                 <div class="success-bar">
-                  <div class="success-bar-fill" style="width: 95.4%"></div>
+                  <div class="success-bar-fill" style="width: {{ sprint.success_rate }}%"></div>
                 </div>
-                <span>95.4%</span>
+                <span>{{ sprint.success_rate }}%</span>
               </div>
             </td>
           </tr>
+          {% else %}
           <tr>
-            <td>Sprint 10</td>
-            <td>May 30 - Jun 13</td>
-            <td><span class="status-badge completed">Completed</span></td>
-            <td>92 / 92</td>
-            <td>
-              <div class="success-rate-cell">
-                <div class="success-bar">
-                  <div class="success-bar-fill" style="width: 100%"></div>
-                </div>
-                <span>100%</span>
-              </div>
-            </td>
+            <td colspan="5" class="text-center text-muted">No completed sprints yet.</td>
           </tr>
-          <tr>
-            <td>Sprint 9</td>
-            <td>May 15 - May 29</td>
-            <td><span class="status-badge completed">Completed</span></td>
-            <td>78 / 85</td>
-            <td>
-              <div class="success-rate-cell">
-                <div class="success-bar">
-                  <div class="success-bar-fill" style="width: 91.7%"></div>
-                </div>
-                <span>91.7%</span>
-              </div>
-            </td>
-          </tr>
-          <tr>
-            <td>Sprint 8</td>
-            <td>May 01 - May 14</td>
-            <td><span class="status-badge completed">Completed</span></td>
-            <td>85 / 85</td>
-            <td>
-              <div class="success-rate-cell">
-                <div class="success-bar">
-                  <div class="success-bar-fill" style="width: 100%"></div>
-                </div>
-                <span>100%</span>
-              </div>
-            </td>
-          </tr>
+          {% endfor %}
         </tbody>
       </table>
     </div>

--- a/app/templates/sprints.html
+++ b/app/templates/sprints.html
@@ -139,6 +139,7 @@
             <th>DURATION</th>
             <th>STORY POINTS</th>
             <th>STATUS</th>
+            <th>ACTION</th>
           </tr>
         </thead>
         <tbody>
@@ -149,10 +150,15 @@
             <td>{{ sprint.duration }}</td>
             <td>{{ sprint.story_points }}</td>
             <td><span class="status-badge todo">{{ sprint.status }}</span></td>
+            <td>
+              <form method="POST" action="{{ url_for('activate_sprint', sprint_id=sprint.id) }}">
+                <button type="submit" class="btn btn-sm primary-action-btn">Activate</button>
+              </form>
+            </td>
           </tr>
           {% else %}
           <tr>
-            <td colspan="5" class="text-center text-muted">No planned sprints yet.</td>
+            <td colspan="6" class="text-center text-muted">No planned sprints yet.</td>
           </tr>
           {% endfor %}
         </tbody>

--- a/seed_db.py
+++ b/seed_db.py
@@ -1,5 +1,5 @@
 from app import create_app, db
-from app.models import User, Project, Task
+from app.models import User, Project, Sprint, Task
 from datetime import date
 from werkzeug.security import generate_password_hash
 
@@ -10,6 +10,7 @@ with app.app_context():
 
     # Clear existing data
     Task.query.delete()
+    Sprint.query.delete()
     Project.query.delete()
     User.query.delete()
     db.session.commit()
@@ -84,33 +85,85 @@ with app.app_context():
     print("Projects seeded successfully.")
 
     # -------------------------
+    # Create sample sprints
+    # -------------------------
+
+    # These sprints make the dashboard and sprints page show realistic data.
+    sprint1 = Sprint(
+        project_id=p1.id,
+        name="Sprint 12",
+        goal="Finalize core financial engine integration and test the main API workflow.",
+        status="active",
+        start_date=date(2026, 10, 14),
+        end_date=date(2026, 10, 28),
+        total_story_points=62,
+        completed_story_points=24,
+        velocity_points=42,
+    )
+
+    sprint2 = Sprint(
+        project_id=p1.id,
+        name="Sprint 11",
+        goal="Complete project setup and prepare first user testing cycle.",
+        status="completed",
+        start_date=date(2026, 9, 30),
+        end_date=date(2026, 10, 13),
+        total_story_points=54,
+        completed_story_points=50,
+        velocity_points=50,
+    )
+
+    sprint3 = Sprint(
+        project_id=p2.id,
+        name="Sprint 5",
+        goal="Improve checkout screens and review mobile layout issues.",
+        status="completed",
+        start_date=date(2026, 9, 16),
+        end_date=date(2026, 9, 29),
+        total_story_points=40,
+        completed_story_points=36,
+        velocity_points=36,
+    )
+
+    db.session.add_all([sprint1, sprint2, sprint3])
+    db.session.commit()
+
+    print("Sprints seeded successfully.")
+
+    # -------------------------
     # Create sample tasks
     # -------------------------
 
     t1 = Task(
         title="Update API Documentation",
         project_id=p1.id,
+        sprint_id=sprint1.id,
         assignee_id=user1.id,
         status="in_progress",
         priority="high",
+        story_points=8,
         due_date=date(2026, 10, 24),
     )
 
     t2 = Task(
         title="Finalize UI Kit Components",
         project_id=p2.id,
+        sprint_id=sprint1.id,
         assignee_id=user1.id,
         status="todo",
         priority="medium",
+        story_points=5,
         due_date=date(2026, 10, 26),
     )
 
     t3 = Task(
         title="Database Indexing Review",
         project_id=p3.id,
+        sprint_id=sprint1.id,
         assignee_id=user1.id,
-        status="todo",
+        status="blocker",
         priority="low",
+        story_points=11,
         due_date=date(2026, 10, 28),
     )
 


### PR DESCRIPTION
**Description**

This PR makes the Sprints page functional using real database data.

**What was added**

loaded active, planned, and completed sprints from the database  
updated the Sprints page to show dynamic sprint details, progress, velocity, and story points  
added sample sprint data to `seed_db.py` for testing
added a Create New Sprint modal and backend save logic  
added validation for sprint name, project, dates, and story points  
added a Planned Sprints section so newly created sprints are visible  
added an Activate Sprint action to move planned sprints into active state  
added a Complete Sprint action to move active sprints into past/completed sprints  
updated the shared topbar button so it can open a modal  
updated `.gitignore` to ignore local upload, log, and SQLite journal files  

**Key files changed**

app/__init__.py  
app/templates/sprints.html  
app/templates/components/topbar.html  
seed_db.py  
.gitignore  

**Testing**

Tested manually in the browser by viewing the Sprints page, creating a sprint, activating it, and completing it.  

Also tested backend flows with Flask test client:
- render Sprints page
- create sprint
- activate sprint
- complete sprint

Closes #20
