### PR TITLE
Remove help icon and bell icon from common layouts.

### DIFF
--- a/app/templates/components/sidebar.html
+++ b/app/templates/components/sidebar.html
@@ -47,9 +47,6 @@
 
     <div class="sidebar-bottom">
       <a href="#" class="nav-link">
-        <i class="bi bi-question-circle me-2"></i> Help
-      </a>
-      <a href="#" class="nav-link">
         <i class="bi bi-gear me-2"></i> Settings
       </a>
     </div>

--- a/app/templates/components/topbar.html
+++ b/app/templates/components/topbar.html
@@ -27,8 +27,6 @@
       {{ topbar_action_label }}
     </button>
     {% endif %}
-    <i class="bi bi-bell"></i>
-    <i class="bi bi-gear"></i>
 
     <div class="profile-box d-flex align-items-center gap-2">
       <div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -63,7 +63,6 @@
           <div class="d-flex flex-wrap gap-3 mb-4">
             <!-- Flask route for authentication page -->
             <a href="{{ url_for('auth') }}" class="btn-primary-green">Get started — it's free</a>
-            <a href="#how-it-works" class="btn-outline-hero">View demo</a>
           </div>
           <div class="d-flex flex-wrap gap-4">
             <span class="hero-check"><i class="fas fa-check-circle"></i> Sprint planning</span>


### PR DESCRIPTION
Description
- This is a small change to remove help icon and bell icon from common layouts of the app, because these are not needed as per the design discussion.
- removed unused View Demo button from Landing page

Closes issue #27 