### PR TITLE
Add sprint health check-in functionality

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -379,6 +379,55 @@ def create_app():
             form_data=form_data,
         )
 
+    @app.route("/sprints/<int:sprint_id>/check-in", methods=["POST"])
+    def submit_sprint_checkin(sprint_id):
+        if g.user is None:
+            return redirect(url_for("auth", mode="login"))
+
+        sprint = db.session.get(Sprint, sprint_id)
+        if not sprint or sprint.status != "active":
+            flash("Check-ins can only be added for the active sprint.", "error")
+            return redirect(url_for("sprints"))
+
+        blockers = request.form.get("blockers", "").strip()
+        needs_help = request.form.get("needs_help") == "on"
+
+        try:
+            confidence_level = int(request.form.get("confidence_level", ""))
+            workload_level = int(request.form.get("workload_level", ""))
+        except ValueError:
+            flash("Confidence and workload must be selected.", "error")
+            return redirect(url_for("sprints"))
+
+        if confidence_level not in range(1, 6) or workload_level not in range(1, 6):
+            flash("Confidence and workload must be between 1 and 5.", "error")
+            return redirect(url_for("sprints"))
+
+        today = date.today()
+        # A user should only have one check-in per sprint per day, so update if it exists.
+        checkin = SprintCheckIn.query.filter_by(
+            sprint_id=sprint.id,
+            user_id=g.user.id,
+            checkin_date=today,
+        ).first()
+
+        if checkin is None:
+            checkin = SprintCheckIn(
+                sprint_id=sprint.id,
+                user_id=g.user.id,
+                checkin_date=today,
+            )
+            db.session.add(checkin)
+
+        checkin.confidence_level = confidence_level
+        checkin.workload_level = workload_level
+        checkin.blockers = blockers
+        checkin.needs_help = needs_help
+        db.session.commit()
+
+        flash("Sprint check-in saved.", "success")
+        return redirect(url_for("sprints") + "#health")
+
     @app.route("/sprints/<int:sprint_id>/activate", methods=["POST"])
     def activate_sprint(sprint_id):
         if g.user is None:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -31,7 +31,7 @@ def create_app():
 
     # Import models so SQLAlchemy and migrations can detect them
     from app import models
-    from app.models import Project, Sprint, Task, User
+    from app.models import Project, Sprint, SprintCheckIn, Task, User
 
     # Register API blueprint
     from app.routes import api
@@ -288,6 +288,13 @@ def create_app():
             "day_label": "Days",
             "end_label": "No end date",
         }
+        sprint_health = {
+            "confidence_label": "No check-ins",
+            "checkin_label": "0 check-ins",
+            "workload_label": "No workload data",
+            "blocker_count": 0,
+            "help_count": 0,
+        }
 
         if active_sprint:
             days_left = max((active_sprint.end_date - date.today()).days, 0)
@@ -311,6 +318,28 @@ def create_app():
                 "day_label": "Day" if days_left == 1 else "Days",
                 "end_label": active_sprint.end_date.strftime("Ends %b %d, %Y"),
             }
+
+            # Sprint health is based on team check-ins saved for the active sprint.
+            checkins = SprintCheckIn.query.filter_by(sprint_id=active_sprint.id).all()
+            checkin_count = len(checkins)
+            if checkins:
+                average_confidence = round(
+                    sum(checkin.confidence_level for checkin in checkins) / checkin_count,
+                    1
+                )
+                average_workload = round(
+                    sum(checkin.workload_level for checkin in checkins) / checkin_count,
+                    1
+                )
+                blocker_count = sum(1 for checkin in checkins if checkin.blockers)
+                help_count = sum(1 for checkin in checkins if checkin.needs_help)
+                sprint_health = {
+                    "confidence_label": f"{average_confidence}/5 confidence",
+                    "checkin_label": f"{checkin_count} check-ins",
+                    "workload_label": f"{average_workload}/5 workload",
+                    "blocker_count": blocker_count,
+                    "help_count": help_count,
+                }
 
         # Planned sprints are shown separately so newly created sprints are easy to find.
         upcoming_sprints = []
@@ -344,6 +373,7 @@ def create_app():
             current_sprint=current_sprint,
             upcoming_sprints=upcoming_sprints,
             past_sprints=past_sprints,
+            sprint_health=sprint_health,
             projects=projects,
             sprint_errors=sprint_errors,
             form_data=form_data,

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -295,6 +295,7 @@ def create_app():
             "blocker_count": 0,
             "help_count": 0,
         }
+        recent_checkins = []
 
         if active_sprint:
             days_left = max((active_sprint.end_date - date.today()).days, 0)
@@ -320,7 +321,12 @@ def create_app():
             }
 
             # Sprint health is based on team check-ins saved for the active sprint.
-            checkins = SprintCheckIn.query.filter_by(sprint_id=active_sprint.id).all()
+            checkins = (
+                SprintCheckIn.query
+                .filter_by(sprint_id=active_sprint.id)
+                .order_by(SprintCheckIn.checkin_date.desc())
+                .all()
+            )
             checkin_count = len(checkins)
             if checkins:
                 average_confidence = round(
@@ -335,11 +341,24 @@ def create_app():
                 help_count = sum(1 for checkin in checkins if checkin.needs_help)
                 sprint_health = {
                     "confidence_label": f"{average_confidence}/5 confidence",
-                    "checkin_label": f"{checkin_count} check-ins",
+                    "checkin_label": f"{checkin_count} check-in" if checkin_count == 1 else f"{checkin_count} check-ins",
                     "workload_label": f"{average_workload}/5 workload",
                     "blocker_count": blocker_count,
                     "help_count": help_count,
                 }
+
+            recent_checkins = []
+            for checkin in checkins[:5]:
+                user_name = checkin.user.full_name if checkin.user else "Team member"
+                recent_checkins.append({
+                    "user_name": user_name,
+                    "initial": user_name[:1].upper(),
+                    "confidence": checkin.confidence_level,
+                    "workload": checkin.workload_level,
+                    "blockers": checkin.blockers or "No blockers added.",
+                    "needs_help": checkin.needs_help,
+                    "date": checkin.checkin_date.strftime("%b %d"),
+                })
 
         # Planned sprints are shown separately so newly created sprints are easy to find.
         upcoming_sprints = []
@@ -377,6 +396,7 @@ def create_app():
             projects=projects,
             sprint_errors=sprint_errors,
             form_data=form_data,
+            recent_checkins=recent_checkins,
         )
 
     @app.route("/sprints/<int:sprint_id>/check-in", methods=["POST"])

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 from app import db
 
 project_users = db.Table(
@@ -48,6 +48,11 @@ class User(db.Model):
         back_populates="assigned_users"
     )
 
+    sprint_checkins = db.relationship(
+        "SprintCheckIn",
+        back_populates="user",
+        cascade="all, delete-orphan"
+    )
 
     def __repr__(self):
         return f"<User {self.full_name}>"
@@ -141,8 +146,56 @@ class Sprint(db.Model):
         back_populates="sprint"
     )
 
+    checkins = db.relationship(
+        "SprintCheckIn",
+        back_populates="sprint",
+        cascade="all, delete-orphan"
+    )
+
     def __repr__(self):
         return f"<Sprint {self.name}>"
+
+class SprintCheckIn(db.Model):
+    """
+    Stores the short daily sprint health update submitted by a team member.
+    """
+    __tablename__ = "sprint_checkins"
+
+    id = db.Column(db.Integer, primary_key=True)
+
+    sprint_id = db.Column(
+        db.Integer,
+        db.ForeignKey("sprints.id"),
+        nullable=False
+    )
+
+    user_id = db.Column(
+        db.Integer,
+        db.ForeignKey("users.id"),
+        nullable=False
+    )
+
+    checkin_date = db.Column(db.Date, nullable=False, default=date.today)
+    confidence_level = db.Column(db.Integer, nullable=False, default=3)
+    workload_level = db.Column(db.Integer, nullable=False, default=3)
+    blockers = db.Column(db.Text, nullable=True)
+    needs_help = db.Column(db.Boolean, default=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    sprint = db.relationship("Sprint", back_populates="checkins")
+    user = db.relationship("User", back_populates="sprint_checkins")
+
+    __table_args__ = (
+        db.UniqueConstraint(
+            "sprint_id",
+            "user_id",
+            "checkin_date",
+            name="uq_sprint_user_checkin_date"
+        ),
+    )
+
+    def __repr__(self):
+        return f"<SprintCheckIn sprint={self.sprint_id} user={self.user_id}>"
 
 class Task(db.Model):
     """
@@ -213,4 +266,3 @@ class Task(db.Model):
 
     def __repr__(self):
         return f"<Task {self.title}>"
-    

--- a/app/static/css/sprints.css
+++ b/app/static/css/sprints.css
@@ -209,6 +209,94 @@
   flex-wrap: wrap;
 }
 
+.sprints-page .recent-checkins {
+  border-top: 1px solid #e5e7eb;
+  margin-top: 22px;
+  padding-top: 18px;
+}
+
+.sprints-page .recent-checkins-head,
+.sprints-page .recent-checkin-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.sprints-page .recent-checkins-head {
+  margin-bottom: 12px;
+  color: #64748b;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.sprints-page .recent-checkins-title {
+  color: #0b2545;
+  font-size: 1rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.sprints-page .recent-checkin-item {
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: start;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.sprints-page .recent-checkin-item + .recent-checkin-item {
+  margin-top: 10px;
+}
+
+.sprints-page .recent-checkin-avatar {
+  align-items: center;
+  background-color: #d8f3f0;
+  border-radius: 50%;
+  color: #00536b;
+  display: inline-flex;
+  font-weight: 700;
+  height: 40px;
+  justify-content: center;
+  width: 40px;
+}
+
+.sprints-page .recent-checkin-main {
+  min-width: 0;
+}
+
+.sprints-page .recent-checkin-top {
+  color: #64748b;
+  font-size: 0.82rem;
+  margin-bottom: 4px;
+}
+
+.sprints-page .recent-checkin-top strong {
+  color: #0b2545;
+  font-size: 0.92rem;
+}
+
+.sprints-page .recent-checkin-main p {
+  color: #475569;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.sprints-page .recent-checkin-blocker {
+  overflow-wrap: anywhere;
+}
+
+.sprints-page .help-pill {
+  background-color: #fee2e2;
+  border-radius: 999px;
+  color: #b91c1c;
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 5px 9px;
+}
+
 .sprints-page .sprint-side-stack {
   display: grid;
   gap: 18px;
@@ -400,6 +488,15 @@
   .sprints-page .checkin-blockers,
   .sprints-page .checkin-actions {
     grid-column: auto;
+  }
+
+  .sprints-page .recent-checkin-item {
+    grid-template-columns: 40px minmax(0, 1fr);
+  }
+
+  .sprints-page .help-pill {
+    grid-column: 2;
+    justify-self: start;
   }
 
   .sprints-page .time-card-top {

--- a/app/static/css/sprints.css
+++ b/app/static/css/sprints.css
@@ -179,6 +179,36 @@
   line-height: 1.5;
 }
 
+.sprints-page .sprint-checkin-card {
+  padding: 22px 24px;
+}
+
+.sprints-page .checkin-date {
+  color: #64748b;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.sprints-page .sprint-checkin-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  align-items: end;
+}
+
+.sprints-page .checkin-blockers {
+  grid-column: span 2;
+}
+
+.sprints-page .checkin-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  grid-column: span 2;
+  flex-wrap: wrap;
+}
+
 .sprints-page .sprint-side-stack {
   display: grid;
   gap: 18px;
@@ -361,6 +391,15 @@
 @media (max-width: 767.98px) {
   .sprints-page .sprint-metrics-grid {
     grid-template-columns: 1fr;
+  }
+
+  .sprints-page .sprint-checkin-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .sprints-page .checkin-blockers,
+  .sprints-page .checkin-actions {
+    grid-column: auto;
   }
 
   .sprints-page .time-card-top {

--- a/app/static/css/sprints.css
+++ b/app/static/css/sprints.css
@@ -173,6 +173,12 @@
   font-weight: 700;
 }
 
+.sprints-page .sprint-health-note {
+  color: #64748b;
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+
 .sprints-page .sprint-side-stack {
   display: grid;
   gap: 18px;

--- a/app/templates/sprints.html
+++ b/app/templates/sprints.html
@@ -132,6 +132,64 @@
   </div>
 </section>
 
+{% if current_sprint.id %}
+<section class="sprint-history-section sprint-checkin-section">
+  <div class="table-card sprint-checkin-card">
+    <div class="section-heading d-flex justify-content-between align-items-center mb-3">
+      <h2 class="section-title mb-0">Daily Check-in</h2>
+      <span class="checkin-date">{{ current_sprint.status }}</span>
+    </div>
+
+    <form method="POST" action="{{ url_for('submit_sprint_checkin', sprint_id=current_sprint.id) }}">
+      <div class="sprint-checkin-grid">
+        <div>
+          <label class="form-label fw-semibold" for="confidence_level">Confidence</label>
+          <select class="form-select" id="confidence_level" name="confidence_level" required>
+            <option value="">Select level</option>
+            <option value="1">1 - Very low</option>
+            <option value="2">2 - Low</option>
+            <option value="3">3 - Okay</option>
+            <option value="4">4 - Good</option>
+            <option value="5">5 - Very confident</option>
+          </select>
+        </div>
+
+        <div>
+          <label class="form-label fw-semibold" for="workload_level">Workload</label>
+          <select class="form-select" id="workload_level" name="workload_level" required>
+            <option value="">Select level</option>
+            <option value="1">1 - Light</option>
+            <option value="2">2 - Manageable</option>
+            <option value="3">3 - Normal</option>
+            <option value="4">4 - Heavy</option>
+            <option value="5">5 - Too much</option>
+          </select>
+        </div>
+
+        <div class="checkin-blockers">
+          <label class="form-label fw-semibold" for="blockers">Blockers</label>
+          <textarea
+            class="form-control"
+            id="blockers"
+            name="blockers"
+            rows="2"
+            placeholder="Add blockers or leave blank"
+          ></textarea>
+        </div>
+
+        <div class="checkin-actions">
+          <label class="form-check mb-3">
+            <input class="form-check-input" type="checkbox" name="needs_help" />
+            <span class="form-check-label">I need help</span>
+          </label>
+          <button type="submit" class="btn primary-action-btn">Save Check-in</button>
+        </div>
+      </div>
+    </form>
+  </div>
+</section>
+{% endif %}
+
 <section class="sprint-history-section">
   <div class="table-card sprint-history-card">
     <div class="section-heading d-flex justify-content-between align-items-center mb-3">

--- a/app/templates/sprints.html
+++ b/app/templates/sprints.html
@@ -85,11 +85,15 @@
         <div class="metric-icon">
           <i class="bi bi-bar-chart-line-fill"></i>
         </div>
-        <p class="card-label mb-2">SPRINT STATUS</p>
+        <p class="card-label mb-2">TEAM HEALTH</p>
         <h4 class="sprint-metric-title">
-          {{ current_sprint.status }}
-          <span class="trend-pill">{{ current_sprint.progress }}%</span>
+          {{ sprint_health.confidence_label }}
+          <span class="trend-pill">{{ sprint_health.checkin_label }}</span>
         </h4>
+        <p class="sprint-health-note mb-0">
+          {{ sprint_health.workload_label }} · {{ sprint_health.blocker_count }} blockers ·
+          {{ sprint_health.help_count }} need help
+        </p>
       </div>
     </div>
   </div>

--- a/app/templates/sprints.html
+++ b/app/templates/sprints.html
@@ -186,6 +186,34 @@
         </div>
       </div>
     </form>
+
+    <div class="recent-checkins">
+      <div class="recent-checkins-head">
+        <h3 class="recent-checkins-title">Recent Check-ins</h3>
+        <span>{{ recent_checkins | length }} shown</span>
+      </div>
+
+      {% for checkin in recent_checkins %}
+      <div class="recent-checkin-item">
+        <span class="recent-checkin-avatar">{{ checkin.initial }}</span>
+        <div class="recent-checkin-main">
+          <div class="recent-checkin-top">
+            <strong>{{ checkin.user_name }}</strong>
+            <span>{{ checkin.date }}</span>
+          </div>
+          <p class="mb-1">
+            Confidence {{ checkin.confidence }}/5 · Workload {{ checkin.workload }}/5
+          </p>
+          <p class="recent-checkin-blocker mb-0">{{ checkin.blockers }}</p>
+        </div>
+        {% if checkin.needs_help %}
+        <span class="help-pill">Needs help</span>
+        {% endif %}
+      </div>
+      {% else %}
+      <p class="text-muted mb-0">No check-ins have been submitted for this sprint yet.</p>
+      {% endfor %}
+    </div>
   </div>
 </section>
 {% endif %}

--- a/migrations/versions/d4b7c2f1a9e3_add_sprint_checkins_table.py
+++ b/migrations/versions/d4b7c2f1a9e3_add_sprint_checkins_table.py
@@ -1,0 +1,44 @@
+"""add sprint checkins table
+
+Revision ID: d4b7c2f1a9e3
+Revises: bcffa5f26224
+Create Date: 2026-05-04 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "d4b7c2f1a9e3"
+down_revision = "bcffa5f26224"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "sprint_checkins",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("sprint_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("checkin_date", sa.Date(), nullable=False),
+        sa.Column("confidence_level", sa.Integer(), nullable=False),
+        sa.Column("workload_level", sa.Integer(), nullable=False),
+        sa.Column("blockers", sa.Text(), nullable=True),
+        sa.Column("needs_help", sa.Boolean(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["sprint_id"], ["sprints.id"]),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "sprint_id",
+            "user_id",
+            "checkin_date",
+            name="uq_sprint_user_checkin_date"
+        )
+    )
+
+
+def downgrade():
+    op.drop_table("sprint_checkins")

--- a/seed_db.py
+++ b/seed_db.py
@@ -1,5 +1,5 @@
 from app import create_app, db
-from app.models import User, Project, Sprint, Task, project_users
+from app.models import User, Project, Sprint, SprintCheckIn, Task, project_users
 from datetime import date, datetime
 from werkzeug.security import generate_password_hash
 
@@ -9,11 +9,12 @@ app = create_app()
 with app.app_context():
 
     # Clear existing data
+    SprintCheckIn.query.delete()
     Task.query.delete()
+    db.session.execute(project_users.delete())
     Sprint.query.delete()
     Project.query.delete()
     User.query.delete()
-    db.session.execute(project_users.delete())
     db.session.commit()
 
     # -------------------------
@@ -300,7 +301,56 @@ with app.app_context():
 
     print("Tasks seeded successfully.")
 
-  # -------------------------
+    # -------------------------
+    # Create sample sprint health check-ins
+    # -------------------------
+
+    # These check-ins give the sprint health page realistic demo data.
+    checkins = [
+        SprintCheckIn(
+            sprint_id=sprint1.id,
+            user_id=user1.id,
+            checkin_date=date.today(),
+            confidence_level=4,
+            workload_level=3,
+            blockers="",
+            needs_help=False,
+        ),
+        SprintCheckIn(
+            sprint_id=sprint1.id,
+            user_id=user2.id,
+            checkin_date=date.today(),
+            confidence_level=3,
+            workload_level=4,
+            blockers="Waiting for final API response examples.",
+            needs_help=True,
+        ),
+        SprintCheckIn(
+            sprint_id=sprint1.id,
+            user_id=user3.id,
+            checkin_date=date.today(),
+            confidence_level=2,
+            workload_level=5,
+            blockers="Database indexing review is taking longer than expected.",
+            needs_help=True,
+        ),
+        SprintCheckIn(
+            sprint_id=sprint1.id,
+            user_id=user4.id,
+            checkin_date=date.today(),
+            confidence_level=4,
+            workload_level=2,
+            blockers="",
+            needs_help=False,
+        ),
+    ]
+
+    db.session.add_all(checkins)
+    db.session.commit()
+
+    print("Sprint health check-ins seeded successfully.")
+
+    # -------------------------
     # Create projects-user relationships
     # -------------------------
 


### PR DESCRIPTION
**Description**

This PR adds Sprint Health functionality so team members can submit daily check-ins for the active sprint and view the team's current sprint health.

**What was added**

added a SprintCheckIn model to store daily sprint health updates
added a database migration for sprint check-ins
added sample sprint health data to the seed script
calculated sprint health summary from database check-ins
added a daily check-in form for the active sprint
updated a user's check-in for the same sprint and day
showed recent team check-ins on the sprints page
showed blockers and help requests in the sprint health summary

**Key files changed**

app/models.py
app/__init__.py
app/templates/sprints.html
app/static/css/sprints.css
seed_db.py
migrations/versions/d4b7c2f1a9e3_add_sprint_checkins_table.py

**Testing**

Tested locally by activating a sprint, submitting a check-in, and confirming the sprint health summary and recent check-ins updated correctly.

Closes #26
