### PR TITLE
Remove search bar from dashboard and sprint pages

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 {% set topbar_title = 'Dashboard' %}
-{% set topbar_search_placeholder = 'Search projects...' %}
+{% set topbar_search_class = 'd-none' %}
 {% include "components/topbar.html" %}
 
 <section class="welcome-section">

--- a/app/templates/sprints.html
+++ b/app/templates/sprints.html
@@ -14,7 +14,7 @@
 {% block content %}
 {% set topbar_title = 'Sprints' %}
 {% set topbar_search_placeholder = 'Search tasks or sprints...' %}
-{% set topbar_search_class = 'sprint-search-box' %}
+{% set topbar_search_class = 'd-none' %}
 {% set topbar_action_label = '+ New Sprint' %}
 {% set topbar_action_class = 'primary-action-btn' %}
 {% set topbar_action_modal_id = 'newSprintModal' %}


### PR DESCRIPTION
## Description
Removed the non-functional search bar from the dashboard and sprint pages.

## What was changed
- Removed search bar from dashboard page
<img width="961" height="514" alt="截屏2026-05-06 上午11 24 48" src="https://github.com/user-attachments/assets/9b1c9250-d028-4a00-a3b6-d22a402109d3" />


- Removed search bar from sprint page
<img width="1916" height="1028" alt="截屏2026-05-06 上午11 24 31" src="https://github.com/user-attachments/assets/2f3de4e0-a5bd-43ed-843b-a23a51bc8fff" />

## Key files changed
- app/templates/dashboard.html
- app/templates/sprints.html

## Testing
Tested manually by logging in and verifying the search bar is no longer visible on the dashboard and sprint pages.

