### PR TITLE
[Feature] Add Settings Page – Account Info, Password Change & Notifications

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -550,6 +550,61 @@ def create_app():
             success = True
 
         return render_template("profile.html", user=user, tasks=tasks, success=success)
+    
+    @app.route('/settings', methods=['GET', 'POST'])
+    def settings():
+        if g.user is None:
+            return redirect(url_for('auth', mode='login'))
+
+        if request.method == 'POST':
+            action = request.form.get('action')
+
+            if action == 'save_profile':
+                full_name = request.form.get('full_name', '').strip()
+                email     = request.form.get('email', '').strip()
+                job_title = request.form.get('job_title', '').strip()
+                location  = request.form.get('location', '').strip()
+
+                if not full_name:
+                    flash('Full name cannot be empty.', 'danger')
+                    return redirect(url_for('settings'))
+
+                avatar_file = request.files.get('avatar')
+                if avatar_file and avatar_file.filename:
+                    filename = secure_filename(f"user_{g.user.id}_{avatar_file.filename}")
+                    upload_path = os.path.join(app.root_path, 'static', 'uploads', filename)
+                    avatar_file.save(upload_path)
+                    g.user.avatar_url = filename
+
+                g.user.full_name = full_name
+                g.user.email     = email
+                g.user.title     = job_title
+                g.user.location  = location
+                db.session.commit()
+                flash('Settings saved successfully.', 'success')
+                return redirect(url_for('settings'))
+
+            elif action == 'change_password':
+                current_password = request.form.get('current_password', '')
+                new_password     = request.form.get('new_password', '')
+                confirm_password = request.form.get('confirm_password', '')
+
+                if not check_password_hash(g.user.password, current_password):
+                    flash('Current password is incorrect.', 'danger')
+                    return redirect(url_for('settings'))
+                if len(new_password) < 8:
+                    flash('New password must be at least 8 characters.', 'danger')
+                    return redirect(url_for('settings'))
+                if new_password != confirm_password:
+                    flash('Passwords do not match.', 'danger')
+                    return redirect(url_for('settings'))
+
+                g.user.password = generate_password_hash(new_password)
+                db.session.commit()
+                flash('Password updated successfully.', 'success')
+                return redirect(url_for('settings'))
+
+        return render_template('settings.html')
 
     with app.app_context():
         db.create_all()

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -683,25 +683,6 @@ def create_app():
                 flash('Settings saved successfully.', 'success')
                 return redirect(url_for('settings'))
 
-            elif action == 'change_password':
-                current_password = request.form.get('current_password', '')
-                new_password     = request.form.get('new_password', '')
-                confirm_password = request.form.get('confirm_password', '')
-
-                if not check_password_hash(g.user.password, current_password):
-                    flash('Current password is incorrect.', 'danger')
-                    return redirect(url_for('settings'))
-                if len(new_password) < 8:
-                    flash('New password must be at least 8 characters.', 'danger')
-                    return redirect(url_for('settings'))
-                if new_password != confirm_password:
-                    flash('Passwords do not match.', 'danger')
-                    return redirect(url_for('settings'))
-
-                g.user.password = generate_password_hash(new_password)
-                db.session.commit()
-                flash('Password updated successfully.', 'success')
-                return redirect(url_for('settings'))
 
         return render_template('settings.html')
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -716,61 +716,7 @@ def create_app():
 
         return render_template('settings.html')
 
-    @app.route('/settings', methods=['GET', 'POST'])
-    def settings():
-        if g.user is None:
-            return redirect(url_for('auth', mode='login'))
-
-        if request.method == 'POST':
-            action = request.form.get('action')
-
-            if action == 'save_profile':
-                full_name = request.form.get('full_name', '').strip()
-                email     = request.form.get('email', '').strip()
-                job_title = request.form.get('job_title', '').strip()
-                location  = request.form.get('location', '').strip()
-
-                if not full_name:
-                    flash('Full name cannot be empty.', 'danger')
-                    return redirect(url_for('settings'))
-
-                avatar_file = request.files.get('avatar')
-                if avatar_file and avatar_file.filename:
-                    filename = secure_filename(f"user_{g.user.id}_{avatar_file.filename}")
-                    upload_path = os.path.join(app.root_path, 'static', 'uploads', filename)
-                    avatar_file.save(upload_path)
-                    g.user.avatar_url = filename
-
-                g.user.full_name = full_name
-                g.user.email     = email
-                g.user.title     = job_title
-                g.user.location  = location
-                db.session.commit()
-                flash('Settings saved successfully.', 'success')
-                return redirect(url_for('settings'))
-
-            elif action == 'change_password':
-                current_password = request.form.get('current_password', '')
-                new_password     = request.form.get('new_password', '')
-                confirm_password = request.form.get('confirm_password', '')
-
-                if not check_password_hash(g.user.password, current_password):
-                    flash('Current password is incorrect.', 'danger')
-                    return redirect(url_for('settings'))
-                if len(new_password) < 8:
-                    flash('New password must be at least 8 characters.', 'danger')
-                    return redirect(url_for('settings'))
-                if new_password != confirm_password:
-                    flash('Passwords do not match.', 'danger')
-                    return redirect(url_for('settings'))
-
-                g.user.password = generate_password_hash(new_password)
-                db.session.commit()
-                flash('Password updated successfully.', 'success')
-                return redirect(url_for('settings'))
-
-        return render_template('settings.html')
-
+    
     with app.app_context():
         db.create_all()
 

--- a/app/static/css/settings.css
+++ b/app/static/css/settings.css
@@ -1,0 +1,390 @@
+/* ── Settings Page ── */
+
+.settings-wrapper {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 28px 32px;
+}
+
+.settings-page-title {
+    font-size: 24px;
+    font-weight: 700;
+    color: #0d2233;
+    margin-bottom: 4px;
+}
+
+.settings-page-sub {
+    font-size: 14px;
+    color: #6b7280;
+    margin-bottom: 28px;
+}
+
+/* ── Section Card ── */
+.settings-card {
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    padding: 28px 32px;
+    margin-bottom: 20px;
+}
+
+.settings-section-heading {
+    font-size: 15px;
+    font-weight: 600;
+    color: #1D9E75;
+    margin-bottom: 20px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.settings-section-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: #e6f7f2;
+    color: #1D9E75;
+    font-size: 12px;
+    font-weight: 700;
+    flex-shrink: 0;
+}
+
+/* ── Section 1: Account ── */
+.account-display {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+}
+
+.account-avatar-wrap {
+    position: relative;
+    flex-shrink: 0;
+}
+
+.account-avatar {
+    width: 72px;
+    height: 72px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 3px solid #1D9E75;
+}
+
+.account-avatar-initials {
+    width: 72px;
+    height: 72px;
+    border-radius: 50%;
+    background: #1D9E75;
+    color: #fff;
+    font-size: 26px;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 3px solid #1D9E75;
+}
+
+.account-info {
+    flex: 1;
+}
+
+.account-name {
+    font-size: 18px;
+    font-weight: 700;
+    color: #0d2233;
+    margin-bottom: 2px;
+}
+
+.account-role {
+    font-size: 13px;
+    color: #6b7280;
+    margin-bottom: 8px;
+}
+
+.account-meta {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.account-meta-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    color: #6b7280;
+}
+
+.account-meta-item i {
+    font-size: 13px;
+    color: #1D9E75;
+}
+
+.btn-upload {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    border: 1px solid #d1d5db;
+    border-radius: 8px;
+    background: #fff;
+    color: #374151;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s;
+    white-space: nowrap;
+}
+
+.btn-upload:hover {
+    background: #f9fafb;
+    border-color: #1D9E75;
+    color: #1D9E75;
+}
+
+/* ── Section 2: Account Information ── */
+.info-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 16px;
+}
+
+@media (max-width: 900px) {
+    .info-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+.form-label-settings {
+    font-size: 12px;
+    font-weight: 600;
+    color: #6b7280;
+    margin-bottom: 6px;
+    display: block;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+}
+
+.form-input-settings {
+    width: 100%;
+    padding: 9px 12px;
+    border: 1px solid #d1d5db;
+    border-radius: 8px;
+    font-size: 14px;
+    color: #0d2233;
+    background: #fff;
+    outline: none;
+    transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.form-input-settings:focus {
+    border-color: #1D9E75;
+    box-shadow: 0 0 0 3px rgba(29, 158, 117, 0.12);
+}
+
+/* ── Section 3: Login & Security ── */
+.security-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 0;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+.security-row:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.security-row-left h6 {
+    font-size: 14px;
+    font-weight: 600;
+    color: #0d2233;
+    margin-bottom: 3px;
+}
+
+.security-row-left p {
+    font-size: 13px;
+    color: #6b7280;
+    margin: 0;
+}
+
+.btn-change-pw {
+    padding: 7px 16px;
+    border: 1px solid #d1d5db;
+    border-radius: 8px;
+    background: #fff;
+    color: #374151;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.15s, border-color 0.15s;
+}
+
+.btn-change-pw:hover {
+    background: #f9fafb;
+    border-color: #1D9E75;
+    color: #1D9E75;
+}
+
+/* ── Toggle Switch ── */
+.toggle-switch {
+    position: relative;
+    width: 44px;
+    height: 24px;
+    flex-shrink: 0;
+}
+
+.toggle-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.toggle-slider {
+    position: absolute;
+    inset: 0;
+    background: #d1d5db;
+    border-radius: 24px;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+.toggle-slider::before {
+    content: '';
+    position: absolute;
+    width: 18px;
+    height: 18px;
+    left: 3px;
+    top: 3px;
+    background: #fff;
+    border-radius: 50%;
+    transition: transform 0.2s;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+}
+
+.toggle-switch input:checked + .toggle-slider {
+    background: #1D9E75;
+}
+
+.toggle-switch input:checked + .toggle-slider::before {
+    transform: translateX(20px);
+}
+
+/* ── Bottom Action Bar ── */
+.settings-action-bar {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    margin-top: 8px;
+    padding-bottom: 32px;
+}
+
+.btn-save {
+    padding: 10px 28px;
+    background: #1D9E75;
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.btn-save:hover {
+    background: #17876a;
+}
+
+.btn-logout {
+    padding: 10px 24px;
+    background: #fff;
+    color: #e53e3e;
+    border: 1px solid #fca5a5;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    transition: background 0.15s;
+}
+
+.btn-logout:hover {
+    background: #fff5f5;
+}
+
+/* ── Change Password Modal ── */
+.modal-content {
+    border-radius: 12px;
+    border: none;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.12);
+}
+
+.modal-header {
+    border-bottom: 1px solid #f3f4f6;
+    padding: 20px 24px 16px;
+}
+
+.modal-title {
+    font-size: 16px;
+    font-weight: 700;
+    color: #0d2233;
+}
+
+.modal-body {
+    padding: 20px 24px;
+}
+
+.modal-footer {
+    border-top: 1px solid #f3f4f6;
+    padding: 16px 24px;
+    gap: 10px;
+}
+
+.password-strength-bar {
+    height: 4px;
+    background: #e5e7eb;
+    border-radius: 4px;
+    margin-top: 8px;
+    overflow: hidden;
+}
+
+.password-strength-fill {
+    height: 100%;
+    border-radius: 4px;
+    width: 0%;
+    transition: width 0.3s, background 0.3s;
+}
+
+.strength-label {
+    font-size: 11px;
+    margin-top: 4px;
+    color: #9ca3af;
+}
+
+/* ── Flash messages ── */
+.flash-settings {
+    padding: 12px 16px;
+    border-radius: 8px;
+    font-size: 13px;
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.flash-success {
+    background: #f0faf5;
+    color: #0f6e56;
+    border: 1px solid #5DCAA5;
+}
+
+.flash-danger {
+    background: #fff5f5;
+    color: #a32d2d;
+    border: 1px solid #f09595;
+}

--- a/app/static/css/settings.css
+++ b/app/static/css/settings.css
@@ -1,22 +1,101 @@
 /* ── Settings Page ── */
 
 .settings-wrapper {
-    max-width: 1100px;
-    margin: 0 auto;
-    padding: 28px 32px;
+    padding: 0;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
 }
 
-.settings-page-title {
-    font-size: 24px;
+.settings-topbar {
+    background: #fff;
+    border-bottom: 1px solid #e5e7eb;
+    padding: 0 32px;
+    height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-shrink: 0;
+}
+
+.settings-topbar-title {
+    font-size: 20px;
     font-weight: 700;
     color: #0d2233;
-    margin-bottom: 4px;
+}
+
+.settings-topbar-right {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.topbar-icon-btn {
+    width: 34px;
+    height: 34px;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #6b7280;
+    cursor: pointer;
+    background: none;
+    border: none;
+}
+
+.topbar-user-name {
+    font-size: 14px;
+    font-weight: 600;
+    color: #0d2233;
+    line-height: 1.2;
+}
+
+.topbar-logout {
+    font-size: 11px;
+    font-weight: 700;
+    color: #e53e3e;
+    letter-spacing: 0.3px;
+    text-decoration: none;
+    display: block;
+}
+
+.topbar-logout:hover { color: #c53030; }
+
+.topbar-avatar {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 2px solid #e5e7eb;
+}
+
+.topbar-avatar-initials {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: #1D9E75;
+    color: #fff;
+    font-size: 14px;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* ── Body area ── */
+.settings-body {
+    flex: 1;
+    padding: 24px 32px 20px;
+    overflow-y: auto;
+    display: flex;          /* 加这行 */
+    flex-direction: column; /* 加这行 */
 }
 
 .settings-page-sub {
-    font-size: 14px;
+    font-size: 13px;
     color: #6b7280;
-    margin-bottom: 28px;
+    margin-bottom: 20px;
+    margin-top: -4px;
 }
 
 /* ── Section Card ── */
@@ -24,15 +103,15 @@
     background: #fff;
     border: 1px solid #e5e7eb;
     border-radius: 12px;
-    padding: 28px 32px;
-    margin-bottom: 20px;
+    padding: 20px 28px;
+    margin-bottom: 14px;
 }
 
 .settings-section-heading {
     font-size: 15px;
     font-weight: 600;
     color: #1D9E75;
-    margin-bottom: 20px;
+    margin-bottom: 14px;
     display: flex;
     align-items: center;
     gap: 8px;
@@ -47,7 +126,7 @@
     border-radius: 50%;
     background: #e6f7f2;
     color: #1D9E75;
-    font-size: 12px;
+    font-size: 11px;
     font-weight: 700;
     flex-shrink: 0;
 }
@@ -59,39 +138,34 @@
     gap: 20px;
 }
 
-.account-avatar-wrap {
-    position: relative;
-    flex-shrink: 0;
-}
-
 .account-avatar {
-    width: 72px;
-    height: 72px;
+    width: 64px;
+    height: 64px;
     border-radius: 50%;
     object-fit: cover;
     border: 3px solid #1D9E75;
+    flex-shrink: 0;
 }
 
 .account-avatar-initials {
-    width: 72px;
-    height: 72px;
+    width: 64px;
+    height: 64px;
     border-radius: 50%;
     background: #1D9E75;
     color: #fff;
-    font-size: 26px;
+    font-size: 24px;
     font-weight: 700;
     display: flex;
     align-items: center;
     justify-content: center;
     border: 3px solid #1D9E75;
+    flex-shrink: 0;
 }
 
-.account-info {
-    flex: 1;
-}
+.account-info { flex: 1; }
 
 .account-name {
-    font-size: 18px;
+    font-size: 17px;
     font-weight: 700;
     color: #0d2233;
     margin-bottom: 2px;
@@ -100,19 +174,18 @@
 .account-role {
     font-size: 13px;
     color: #6b7280;
-    margin-bottom: 8px;
+    margin-bottom: 6px;
 }
 
 .account-meta {
     display: flex;
-    gap: 16px;
-    flex-wrap: wrap;
+    gap: 18px;
 }
 
 .account-meta-item {
     display: flex;
     align-items: center;
-    gap: 6px;
+    gap: 5px;
     font-size: 13px;
     color: #6b7280;
 }
@@ -127,7 +200,7 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    padding: 8px 16px;
+    padding: 8px 18px;
     border: 1px solid #d1d5db;
     border-radius: 8px;
     background: #fff;
@@ -152,23 +225,19 @@
     gap: 16px;
 }
 
-@media (max-width: 900px) {
-    .info-grid { grid-template-columns: repeat(2, 1fr); }
-}
-
 .form-label-settings {
-    font-size: 12px;
+    font-size: 11px;
     font-weight: 600;
     color: #6b7280;
     margin-bottom: 6px;
     display: block;
     text-transform: uppercase;
-    letter-spacing: 0.4px;
+    letter-spacing: 0.5px;
 }
 
 .form-input-settings {
     width: 100%;
-    padding: 9px 12px;
+    padding: 10px 12px;
     border: 1px solid #d1d5db;
     border-radius: 8px;
     font-size: 14px;
@@ -183,12 +252,19 @@
     box-shadow: 0 0 0 3px rgba(29, 158, 117, 0.12);
 }
 
-/* ── Section 3: Login & Security ── */
+/* ── Sections 3 & 4 side by side ── */
+.security-notification-grid {
+    display: grid;
+    grid-template-columns: 1fr;   /* 把 1fr 1fr 改成 1fr */
+    gap: 14px;
+    margin-bottom: 14px;
+}
+
 .security-row {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 14px 0;
+    padding: 12px 0;
     border-bottom: 1px solid #f3f4f6;
 }
 
@@ -205,7 +281,7 @@
 }
 
 .security-row-left p {
-    font-size: 13px;
+    font-size: 12px;
     color: #6b7280;
     margin: 0;
 }
@@ -220,7 +296,7 @@
     font-weight: 500;
     cursor: pointer;
     white-space: nowrap;
-    transition: background 0.15s, border-color 0.15s;
+    transition: background 0.15s;
 }
 
 .btn-change-pw:hover {
@@ -237,11 +313,7 @@
     flex-shrink: 0;
 }
 
-.toggle-switch input {
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
+.toggle-switch input { opacity: 0; width: 0; height: 0; }
 
 .toggle-slider {
     position: absolute;
@@ -265,21 +337,15 @@
     box-shadow: 0 1px 3px rgba(0,0,0,0.15);
 }
 
-.toggle-switch input:checked + .toggle-slider {
-    background: #1D9E75;
-}
-
-.toggle-switch input:checked + .toggle-slider::before {
-    transform: translateX(20px);
-}
+.toggle-switch input:checked + .toggle-slider { background: #1D9E75; }
+.toggle-switch input:checked + .toggle-slider::before { transform: translateX(20px); }
 
 /* ── Bottom Action Bar ── */
 .settings-action-bar {
     display: flex;
     justify-content: flex-end;
     gap: 12px;
-    margin-top: 8px;
-    padding-bottom: 32px;
+    padding-bottom: 8px;
 }
 
 .btn-save {
@@ -294,12 +360,10 @@
     transition: background 0.15s;
 }
 
-.btn-save:hover {
-    background: #17876a;
-}
+.btn-save:hover { background: #17876a; }
 
-.btn-logout {
-    padding: 10px 24px;
+.btn-logout-bar {
+    padding: 10px 22px;
     background: #fff;
     color: #e53e3e;
     border: 1px solid #fca5a5;
@@ -310,14 +374,13 @@
     display: flex;
     align-items: center;
     gap: 8px;
+    text-decoration: none;
     transition: background 0.15s;
 }
 
-.btn-logout:hover {
-    background: #fff5f5;
-}
+.btn-logout-bar:hover { background: #fff5f5; color: #e53e3e; }
 
-/* ── Change Password Modal ── */
+/* ── Modal ── */
 .modal-content {
     border-radius: 12px;
     border: none;
@@ -326,7 +389,7 @@
 
 .modal-header {
     border-bottom: 1px solid #f3f4f6;
-    padding: 20px 24px 16px;
+    padding: 18px 24px 14px;
 }
 
 .modal-title {
@@ -335,13 +398,11 @@
     color: #0d2233;
 }
 
-.modal-body {
-    padding: 20px 24px;
-}
+.modal-body { padding: 18px 24px; }
 
 .modal-footer {
     border-top: 1px solid #f3f4f6;
-    padding: 16px 24px;
+    padding: 14px 24px;
     gap: 10px;
 }
 
@@ -361,17 +422,17 @@
 }
 
 .strength-label {
-    font-size: 11px;
+    font-size: 12px;
     margin-top: 4px;
     color: #9ca3af;
 }
 
-/* ── Flash messages ── */
+/* ── Flash ── */
 .flash-settings {
     padding: 12px 16px;
     border-radius: 8px;
     font-size: 13px;
-    margin-bottom: 16px;
+    margin-bottom: 14px;
     display: flex;
     align-items: center;
     gap: 10px;
@@ -387,4 +448,14 @@
     background: #fff5f5;
     color: #a32d2d;
     border: 1px solid #f09595;
+}
+
+#settings-form {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+#settings-form .settings-action-bar {
+    margin-top: 20px;   
 }

--- a/app/templates/components/sidebar.html
+++ b/app/templates/components/sidebar.html
@@ -49,9 +49,9 @@
       <a href="#" class="nav-link">
         <i class="bi bi-question-circle me-2"></i> Help
       </a>
-      <a href="#" class="nav-link">
+      <a href="/settings" class="nav-link {% if request.endpoint == 'settings' %}active{% endif %}">
         <i class="bi bi-gear me-2"></i> Settings
-      </a>
+    </a>
     </div>
   </div>
 </aside>

--- a/app/templates/components/topbar.html
+++ b/app/templates/components/topbar.html
@@ -28,7 +28,9 @@
     </button>
     {% endif %}
     <i class="bi bi-bell"></i>
-    <i class="bi bi-gear"></i>
+    <a href="{{ url_for('settings') }}">
+      <i class="bi bi-gear"></i>
+    </a>
 
     <div class="profile-box d-flex align-items-center gap-2">
       <div>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,4 +1,6 @@
+{% set topbar_title = 'Settings' %}
 {% extends "base.html" %}
+{% set topbar_title = 'Settings' %}
 {% set topbar_search_class = 'd-none' %}
 
 {% block title %}Settings{% endblock %}
@@ -8,32 +10,10 @@
 {% endblock %}
 
 {% block content %}
+{% include 'components/topbar.html' %}
 <div class="settings-wrapper">
 
-    <!-- ── Topbar (matches dashboard style) ── -->
-    <div class="settings-topbar">
-        <span class="settings-topbar-title">Settings</span>
-        <div class="settings-topbar-right">
-            <button class="topbar-icon-btn">
-                <i class="bi bi-bell" style="font-size:16px;"></i>
-            </button>
-            <button class="topbar-icon-btn">
-                <i class="bi bi-gear" style="font-size:16px;"></i>
-            </button>
-            <div style="text-align:right;">
-                <div class="topbar-user-name">{{ g.user.full_name or g.user.username }}</div>
-                <a href="{{ url_for('logout') }}" class="topbar-logout">LOG OUT</a>
-            </div>
-            {% if g.user.avatar_url %}
-                <img src="{{ url_for('static', filename='uploads/' + g.user.avatar_url) }}"
-                     alt="Avatar" class="topbar-avatar">
-            {% else %}
-                <div class="topbar-avatar-initials">
-                    {{ g.user.full_name[0].upper() if g.user.full_name else 'U' }}
-                </div>
-            {% endif %}
-        </div>
-    </div>
+
 
     <!-- ── Main body ── -->
     <div class="settings-body">
@@ -131,37 +111,10 @@
             <!-- ── Sections 3 & 4 side by side ── -->
             <div class="security-notification-grid">
 
-                <div class="settings-card" style="margin-bottom:0;">
-                    <div class="settings-section-heading">
-                        <span class="settings-section-number">3</span>
-                        Login &amp; Security
-                    </div>
-                    <div class="security-row">
-                        <div class="security-row-left">
-                            <h6>Change Password</h6>
-                            <p>Update your password regularly to keep your account secure.</p>
-                        </div>
-                        <button type="button" class="btn-change-pw"
-                                data-bs-toggle="modal"
-                                data-bs-target="#changePasswordModal">
-                            Change Password
-                        </button>
-                    </div>
-                    <div class="security-row">
-                        <div class="security-row-left">
-                            <h6>Two-Factor Authentication</h6>
-                            <p>Add an extra layer of security to your account.</p>
-                        </div>
-                        <label class="toggle-switch">
-                            <input type="checkbox" name="tfa_enabled">
-                            <span class="toggle-slider"></span>
-                        </label>
-                    </div>
-                </div>
 
                 <div class="settings-card" style="margin-bottom:0;">
                     <div class="settings-section-heading">
-                        <span class="settings-section-number">4</span>
+                        <span class="settings-section-number">3</span>
                         Notification Settings
                     </div>
                     <div class="security-row">

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -108,38 +108,7 @@
                 </div>
             </div>
 
-            <!-- ── Sections 3 & 4 side by side ── -->
-            <div class="security-notification-grid">
 
-
-                <div class="settings-card" style="margin-bottom:0;">
-                    <div class="settings-section-heading">
-                        <span class="settings-section-number">3</span>
-                        Notification Settings
-                    </div>
-                    <div class="security-row">
-                        <div class="security-row-left">
-                            <h6>Email Notifications</h6>
-                            <p>Receive important updates and alerts via email.</p>
-                        </div>
-                        <label class="toggle-switch">
-                            <input type="checkbox" name="email_notifications" checked>
-                            <span class="toggle-slider"></span>
-                        </label>
-                    </div>
-                    <div class="security-row">
-                        <div class="security-row-left">
-                            <h6>Task Reminders</h6>
-                            <p>Get reminded about tasks and deadlines.</p>
-                        </div>
-                        <label class="toggle-switch">
-                            <input type="checkbox" name="task_reminders" checked>
-                            <span class="toggle-slider"></span>
-                        </label>
-                    </div>
-                </div>
-
-            </div>
 
             <!-- ── Action Bar ── -->
             <div class="settings-action-bar">

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -10,193 +10,197 @@
 {% block content %}
 <div class="settings-wrapper">
 
-    {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-            {% for category, message in messages %}
-                <div class="flash-settings flash-{{ category }}">
-                    {% if category == 'success' %}
-                        <i class="bi bi-check-circle-fill"></i>
-                    {% else %}
-                        <i class="bi bi-exclamation-circle-fill"></i>
-                    {% endif %}
-                    {{ message }}
-                </div>
-            {% endfor %}
-        {% endif %}
-    {% endwith %}
-
-    <h1 class="settings-page-title">Settings</h1>
-    <p class="settings-page-sub">Manage your account and core preferences.</p>
-
-    <form method="POST" action="{{ url_for('settings') }}" enctype="multipart/form-data" id="settings-form">
-
-        <!-- ── Section 1: Account ── -->
-        <div class="settings-card">
-            <div class="settings-section-heading">
-                <span class="settings-section-number">1</span>
-                Account
+    <!-- ── Topbar (matches dashboard style) ── -->
+    <div class="settings-topbar">
+        <span class="settings-topbar-title">Settings</span>
+        <div class="settings-topbar-right">
+            <button class="topbar-icon-btn">
+                <i class="bi bi-bell" style="font-size:16px;"></i>
+            </button>
+            <button class="topbar-icon-btn">
+                <i class="bi bi-gear" style="font-size:16px;"></i>
+            </button>
+            <div style="text-align:right;">
+                <div class="topbar-user-name">{{ g.user.full_name or g.user.username }}</div>
+                <a href="{{ url_for('logout') }}" class="topbar-logout">LOG OUT</a>
             </div>
-            <div class="account-display">
-                <div class="account-avatar-wrap">
+            {% if g.user.avatar_url %}
+                <img src="{{ url_for('static', filename='uploads/' + g.user.avatar_url) }}"
+                     alt="Avatar" class="topbar-avatar">
+            {% else %}
+                <div class="topbar-avatar-initials">
+                    {{ g.user.full_name[0].upper() if g.user.full_name else 'U' }}
+                </div>
+            {% endif %}
+        </div>
+    </div>
+
+    <!-- ── Main body ── -->
+    <div class="settings-body">
+
+        {% with messages = get_flashed_messages(with_categories=true) %}
+            {% if messages %}
+                {% for category, message in messages %}
+                    <div class="flash-settings flash-{{ category }}">
+                        {% if category == 'success' %}
+                            <i class="bi bi-check-circle-fill"></i>
+                        {% else %}
+                            <i class="bi bi-exclamation-circle-fill"></i>
+                        {% endif %}
+                        {{ message }}
+                    </div>
+                {% endfor %}
+            {% endif %}
+        {% endwith %}
+
+        <p class="settings-page-sub">Manage your account and core preferences.</p>
+
+        <form method="POST" action="{{ url_for('settings') }}"
+              enctype="multipart/form-data" id="settings-form">
+
+            <!-- ── Section 1: Account ── -->
+            <div class="settings-card">
+                <div class="settings-section-heading">
+                    <span class="settings-section-number">1</span>
+                    Account
+                </div>
+                <div class="account-display">
                     {% if g.user.avatar_url %}
                         <img src="{{ url_for('static', filename='uploads/' + g.user.avatar_url) }}"
-                             alt="Avatar"
-                             class="account-avatar"
-                             id="avatar-preview">
+                             alt="Avatar" class="account-avatar" id="avatar-preview">
                     {% else %}
                         <div class="account-avatar-initials" id="avatar-initials">
                             {{ g.user.full_name[0].upper() if g.user.full_name else 'U' }}
                         </div>
                     {% endif %}
+                    <div class="account-info">
+                        <div class="account-name">{{ g.user.full_name or g.user.username }}</div>
+                        <div class="account-role">{{ g.user.title or 'No title set' }}</div>
+                        <div class="account-meta">
+                            <span class="account-meta-item">
+                                <i class="bi bi-envelope"></i>
+                                {{ g.user.email }}
+                            </span>
+                            {% if g.user.location %}
+                            <span class="account-meta-item">
+                                <i class="bi bi-geo-alt"></i>
+                                {{ g.user.location }}
+                            </span>
+                            {% endif %}
+                        </div>
+                    </div>
+                    <label class="btn-upload" for="avatar-upload">
+                        <i class="bi bi-upload"></i>
+                        Upload Photo
+                    </label>
+                    <input type="file" id="avatar-upload" name="avatar"
+                           accept="image/*" class="d-none">
                 </div>
-                <div class="account-info">
-                    <div class="account-name">{{ g.user.full_name or g.user.username }}</div>
-                    <div class="account-role">{{ g.user.job_title or 'No title set' }}</div>
-                    <div class="account-meta">
-                        <span class="account-meta-item">
-                            <i class="bi bi-envelope"></i>
-                            {{ g.user.email }}
-                        </span>
-                        {% if g.user.location %}
-                        <span class="account-meta-item">
-                            <i class="bi bi-geo-alt"></i>
-                            {{ g.user.location }}
-                        </span>
-                        {% endif %}
+            </div>
+
+            <!-- ── Section 2: Account Information ── -->
+            <div class="settings-card">
+                <div class="settings-section-heading">
+                    <span class="settings-section-number">2</span>
+                    Account Information
+                </div>
+                <div class="info-grid">
+                    <div>
+                        <label class="form-label-settings">Full Name</label>
+                        <input type="text" name="full_name" class="form-input-settings"
+                               value="{{ g.user.full_name or '' }}" placeholder="Your full name">
+                    </div>
+                    <div>
+                        <label class="form-label-settings">Email</label>
+                        <input type="email" name="email" class="form-input-settings"
+                               value="{{ g.user.email or '' }}" placeholder="your@email.com">
+                    </div>
+                    <div>
+                        <label class="form-label-settings">Role</label>
+                        <input type="text" name="job_title" class="form-input-settings"
+                               value="{{ g.user.title or '' }}" placeholder="e.g. Developer">
+                    </div>
+                    <div>
+                        <label class="form-label-settings">Location</label>
+                        <input type="text" name="location" class="form-input-settings"
+                               value="{{ g.user.location or '' }}" placeholder="e.g. Perth">
                     </div>
                 </div>
-                <label class="btn-upload" for="avatar-upload">
-                    <i class="bi bi-upload"></i>
-                    Upload Photo
-                </label>
-                <input type="file"
-                       id="avatar-upload"
-                       name="avatar"
-                       accept="image/*"
-                       class="d-none">
-            </div>
-        </div>
-
-        <!-- ── Section 2: Account Information ── -->
-        <div class="settings-card">
-            <div class="settings-section-heading">
-                <span class="settings-section-number">2</span>
-                Account Information
-            </div>
-            <div class="info-grid">
-                <div>
-                    <label class="form-label-settings" for="full_name">Full Name</label>
-                    <input type="text"
-                           id="full_name"
-                           name="full_name"
-                           class="form-input-settings"
-                           value="{{ g.user.full_name or '' }}"
-                           placeholder="Your full name">
-                </div>
-                <div>
-                    <label class="form-label-settings" for="email">Email</label>
-                    <input type="email"
-                           id="email"
-                           name="email"
-                           class="form-input-settings"
-                           value="{{ g.user.email or '' }}"
-                           placeholder="your@email.com">
-                </div>
-                <div>
-                    <label class="form-label-settings" for="job_title">Role</label>
-                    <input type="text"
-                           id="job_title"
-                           name="job_title"
-                           class="form-input-settings"
-                           value="{{ g.user.job_title or '' }}"
-                           placeholder="e.g. Developer">
-                </div>
-                <div>
-                    <label class="form-label-settings" for="location">Location</label>
-                    <input type="text"
-                           id="location"
-                           name="location"
-                           class="form-input-settings"
-                           value="{{ g.user.location or '' }}"
-                           placeholder="e.g. Perth">
-                </div>
-            </div>
-        </div>
-
-        <!-- ── Section 3: Login & Security ── -->
-        <div class="settings-card">
-            <div class="settings-section-heading">
-                <span class="settings-section-number">3</span>
-                Login &amp; Security
             </div>
 
-            <div class="security-row">
-                <div class="security-row-left">
-                    <h6>Change Password</h6>
-                    <p>Update your password regularly to keep your account secure.</p>
+            <!-- ── Sections 3 & 4 side by side ── -->
+            <div class="security-notification-grid">
+
+                <div class="settings-card" style="margin-bottom:0;">
+                    <div class="settings-section-heading">
+                        <span class="settings-section-number">3</span>
+                        Login &amp; Security
+                    </div>
+                    <div class="security-row">
+                        <div class="security-row-left">
+                            <h6>Change Password</h6>
+                            <p>Update your password regularly to keep your account secure.</p>
+                        </div>
+                        <button type="button" class="btn-change-pw"
+                                data-bs-toggle="modal"
+                                data-bs-target="#changePasswordModal">
+                            Change Password
+                        </button>
+                    </div>
+                    <div class="security-row">
+                        <div class="security-row-left">
+                            <h6>Two-Factor Authentication</h6>
+                            <p>Add an extra layer of security to your account.</p>
+                        </div>
+                        <label class="toggle-switch">
+                            <input type="checkbox" name="tfa_enabled">
+                            <span class="toggle-slider"></span>
+                        </label>
+                    </div>
                 </div>
-                <button type="button"
-                        class="btn-change-pw"
-                        data-bs-toggle="modal"
-                        data-bs-target="#changePasswordModal">
-                    Change Password
+
+                <div class="settings-card" style="margin-bottom:0;">
+                    <div class="settings-section-heading">
+                        <span class="settings-section-number">4</span>
+                        Notification Settings
+                    </div>
+                    <div class="security-row">
+                        <div class="security-row-left">
+                            <h6>Email Notifications</h6>
+                            <p>Receive important updates and alerts via email.</p>
+                        </div>
+                        <label class="toggle-switch">
+                            <input type="checkbox" name="email_notifications" checked>
+                            <span class="toggle-slider"></span>
+                        </label>
+                    </div>
+                    <div class="security-row">
+                        <div class="security-row-left">
+                            <h6>Task Reminders</h6>
+                            <p>Get reminded about tasks and deadlines.</p>
+                        </div>
+                        <label class="toggle-switch">
+                            <input type="checkbox" name="task_reminders" checked>
+                            <span class="toggle-slider"></span>
+                        </label>
+                    </div>
+                </div>
+
+            </div>
+
+            <!-- ── Action Bar ── -->
+            <div class="settings-action-bar">
+                <button type="submit" name="action" value="save_profile" class="btn-save">
+                    Save Changes
                 </button>
+                <a href="{{ url_for('logout') }}" class="btn-logout-bar">
+                    <i class="bi bi-box-arrow-right"></i>
+                    Log Out
+                </a>
             </div>
 
-            <div class="security-row">
-                <div class="security-row-left">
-                    <h6>Two-Factor Authentication</h6>
-                    <p>Add an extra layer of security to your account.</p>
-                </div>
-                <label class="toggle-switch">
-                    <input type="checkbox" name="tfa_enabled">
-                    <span class="toggle-slider"></span>
-                </label>
-            </div>
-        </div>
-
-        <!-- ── Section 4: Notification Settings ── -->
-        <div class="settings-card">
-            <div class="settings-section-heading">
-                <span class="settings-section-number">4</span>
-                Notification Settings
-            </div>
-
-            <div class="security-row">
-                <div class="security-row-left">
-                    <h6>Email Notifications</h6>
-                    <p>Receive important updates and alerts via email.</p>
-                </div>
-                <label class="toggle-switch">
-                    <input type="checkbox" name="email_notifications" checked>
-                    <span class="toggle-slider"></span>
-                </label>
-            </div>
-
-            <div class="security-row">
-                <div class="security-row-left">
-                    <h6>Task Reminders</h6>
-                    <p>Get reminded about tasks and deadlines.</p>
-                </div>
-                <label class="toggle-switch">
-                    <input type="checkbox" name="task_reminders" checked>
-                    <span class="toggle-slider"></span>
-                </label>
-            </div>
-        </div>
-
-        <!-- ── Action Bar ── -->
-        <div class="settings-action-bar">
-            <button type="submit" name="action" value="save_profile" class="btn-save">
-                Save Changes
-            </button>
-            <a href="{{ url_for('logout') }}" class="btn-logout">
-                <i class="bi bi-box-arrow-right"></i>
-                Log Out
-            </a>
-        </div>
-
-    </form>
+        </form>
+    </div>
 </div>
 
 <!-- ── Change Password Modal ── -->
@@ -210,22 +214,15 @@
             <form method="POST" action="{{ url_for('settings') }}" id="pw-form">
                 <div class="modal-body">
                     <div id="pw-flash" class="flash-settings flash-danger d-none"></div>
-
                     <div class="mb-3">
                         <label class="form-label-settings">Current Password</label>
-                        <input type="password"
-                               name="current_password"
-                               id="current_password"
-                               class="form-input-settings"
-                               placeholder="Enter current password">
+                        <input type="password" name="current_password" id="current_password"
+                               class="form-input-settings" placeholder="Enter current password">
                     </div>
                     <div class="mb-3">
                         <label class="form-label-settings">New Password</label>
-                        <input type="password"
-                               name="new_password"
-                               id="new_password"
-                               class="form-input-settings"
-                               placeholder="At least 8 characters"
+                        <input type="password" name="new_password" id="new_password"
+                               class="form-input-settings" placeholder="At least 8 characters"
                                oninput="checkStrength(this.value)">
                         <div class="password-strength-bar">
                             <div class="password-strength-fill" id="strength-fill"></div>
@@ -234,16 +231,16 @@
                     </div>
                     <div class="mb-1">
                         <label class="form-label-settings">Confirm New Password</label>
-                        <input type="password"
-                               name="confirm_password"
-                               id="confirm_password"
-                               class="form-input-settings"
-                               placeholder="Repeat new password">
+                        <input type="password" name="confirm_password" id="confirm_password"
+                               class="form-input-settings" placeholder="Repeat new password">
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn-outline-secondary btn btn-sm" data-bs-dismiss="modal">Cancel</button>
-                    <button type="button" class="btn-save" onclick="submitPassword()">Update Password</button>
+                    <button type="button" class="btn btn-sm btn-outline-secondary"
+                            data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn-save" onclick="submitPassword()">
+                        Update Password
+                    </button>
                 </div>
             </form>
         </div>
@@ -254,7 +251,6 @@
 
 {% block extra_js %}
 <script>
-// ── Avatar preview ──
 document.getElementById('avatar-upload').addEventListener('change', function(e) {
     var file = e.target.files[0];
     if (!file) return;
@@ -275,7 +271,6 @@ document.getElementById('avatar-upload').addEventListener('change', function(e) 
     reader.readAsDataURL(file);
 });
 
-// ── Password strength ──
 function checkStrength(val) {
     var fill = document.getElementById('strength-fill');
     var label = document.getElementById('strength-label');
@@ -298,26 +293,15 @@ function checkStrength(val) {
     label.style.color = lv.c;
 }
 
-// ── Password form submit ──
 function submitPassword() {
     var cur = document.getElementById('current_password').value.trim();
     var nw  = document.getElementById('new_password').value;
     var cf  = document.getElementById('confirm_password').value;
     var flash = document.getElementById('pw-flash');
-
     flash.classList.add('d-none');
-
-    if (!cur) {
-        showPwFlash('Current password is required.'); return;
-    }
-    if (nw.length < 8) {
-        showPwFlash('New password must be at least 8 characters.'); return;
-    }
-    if (nw !== cf) {
-        showPwFlash('Passwords do not match.'); return;
-    }
-
-    // add hidden action field and submit
+    if (!cur) { showPwFlash('Current password is required.'); return; }
+    if (nw.length < 8) { showPwFlash('New password must be at least 8 characters.'); return; }
+    if (nw !== cf) { showPwFlash('Passwords do not match.'); return; }
     var input = document.createElement('input');
     input.type = 'hidden';
     input.name = 'action';

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -125,49 +125,7 @@
     </div>
 </div>
 
-<!-- ── Change Password Modal ── -->
-<div class="modal fade" id="changePasswordModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Change Password</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-            </div>
-            <form method="POST" action="{{ url_for('settings') }}" id="pw-form">
-                <div class="modal-body">
-                    <div id="pw-flash" class="flash-settings flash-danger d-none"></div>
-                    <div class="mb-3">
-                        <label class="form-label-settings">Current Password</label>
-                        <input type="password" name="current_password" id="current_password"
-                               class="form-input-settings" placeholder="Enter current password">
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label-settings">New Password</label>
-                        <input type="password" name="new_password" id="new_password"
-                               class="form-input-settings" placeholder="At least 8 characters"
-                               oninput="checkStrength(this.value)">
-                        <div class="password-strength-bar">
-                            <div class="password-strength-fill" id="strength-fill"></div>
-                        </div>
-                        <div class="strength-label" id="strength-label"></div>
-                    </div>
-                    <div class="mb-1">
-                        <label class="form-label-settings">Confirm New Password</label>
-                        <input type="password" name="confirm_password" id="confirm_password"
-                               class="form-input-settings" placeholder="Repeat new password">
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-sm btn-outline-secondary"
-                            data-bs-dismiss="modal">Cancel</button>
-                    <button type="button" class="btn-save" onclick="submitPassword()">
-                        Update Password
-                    </button>
-                </div>
-            </form>
-        </div>
-    </div>
-</div>
+
 
 {% endblock %}
 

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,0 +1,335 @@
+{% extends "base.html" %}
+{% set topbar_search_class = 'd-none' %}
+
+{% block title %}Settings{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/settings.css') }}">
+{% endblock %}
+
+{% block content %}
+<div class="settings-wrapper">
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            {% for category, message in messages %}
+                <div class="flash-settings flash-{{ category }}">
+                    {% if category == 'success' %}
+                        <i class="bi bi-check-circle-fill"></i>
+                    {% else %}
+                        <i class="bi bi-exclamation-circle-fill"></i>
+                    {% endif %}
+                    {{ message }}
+                </div>
+            {% endfor %}
+        {% endif %}
+    {% endwith %}
+
+    <h1 class="settings-page-title">Settings</h1>
+    <p class="settings-page-sub">Manage your account and core preferences.</p>
+
+    <form method="POST" action="{{ url_for('settings') }}" enctype="multipart/form-data" id="settings-form">
+
+        <!-- ── Section 1: Account ── -->
+        <div class="settings-card">
+            <div class="settings-section-heading">
+                <span class="settings-section-number">1</span>
+                Account
+            </div>
+            <div class="account-display">
+                <div class="account-avatar-wrap">
+                    {% if g.user.avatar_url %}
+                        <img src="{{ url_for('static', filename='uploads/' + g.user.avatar_url) }}"
+                             alt="Avatar"
+                             class="account-avatar"
+                             id="avatar-preview">
+                    {% else %}
+                        <div class="account-avatar-initials" id="avatar-initials">
+                            {{ g.user.full_name[0].upper() if g.user.full_name else 'U' }}
+                        </div>
+                    {% endif %}
+                </div>
+                <div class="account-info">
+                    <div class="account-name">{{ g.user.full_name or g.user.username }}</div>
+                    <div class="account-role">{{ g.user.job_title or 'No title set' }}</div>
+                    <div class="account-meta">
+                        <span class="account-meta-item">
+                            <i class="bi bi-envelope"></i>
+                            {{ g.user.email }}
+                        </span>
+                        {% if g.user.location %}
+                        <span class="account-meta-item">
+                            <i class="bi bi-geo-alt"></i>
+                            {{ g.user.location }}
+                        </span>
+                        {% endif %}
+                    </div>
+                </div>
+                <label class="btn-upload" for="avatar-upload">
+                    <i class="bi bi-upload"></i>
+                    Upload Photo
+                </label>
+                <input type="file"
+                       id="avatar-upload"
+                       name="avatar"
+                       accept="image/*"
+                       class="d-none">
+            </div>
+        </div>
+
+        <!-- ── Section 2: Account Information ── -->
+        <div class="settings-card">
+            <div class="settings-section-heading">
+                <span class="settings-section-number">2</span>
+                Account Information
+            </div>
+            <div class="info-grid">
+                <div>
+                    <label class="form-label-settings" for="full_name">Full Name</label>
+                    <input type="text"
+                           id="full_name"
+                           name="full_name"
+                           class="form-input-settings"
+                           value="{{ g.user.full_name or '' }}"
+                           placeholder="Your full name">
+                </div>
+                <div>
+                    <label class="form-label-settings" for="email">Email</label>
+                    <input type="email"
+                           id="email"
+                           name="email"
+                           class="form-input-settings"
+                           value="{{ g.user.email or '' }}"
+                           placeholder="your@email.com">
+                </div>
+                <div>
+                    <label class="form-label-settings" for="job_title">Role</label>
+                    <input type="text"
+                           id="job_title"
+                           name="job_title"
+                           class="form-input-settings"
+                           value="{{ g.user.job_title or '' }}"
+                           placeholder="e.g. Developer">
+                </div>
+                <div>
+                    <label class="form-label-settings" for="location">Location</label>
+                    <input type="text"
+                           id="location"
+                           name="location"
+                           class="form-input-settings"
+                           value="{{ g.user.location or '' }}"
+                           placeholder="e.g. Perth">
+                </div>
+            </div>
+        </div>
+
+        <!-- ── Section 3: Login & Security ── -->
+        <div class="settings-card">
+            <div class="settings-section-heading">
+                <span class="settings-section-number">3</span>
+                Login &amp; Security
+            </div>
+
+            <div class="security-row">
+                <div class="security-row-left">
+                    <h6>Change Password</h6>
+                    <p>Update your password regularly to keep your account secure.</p>
+                </div>
+                <button type="button"
+                        class="btn-change-pw"
+                        data-bs-toggle="modal"
+                        data-bs-target="#changePasswordModal">
+                    Change Password
+                </button>
+            </div>
+
+            <div class="security-row">
+                <div class="security-row-left">
+                    <h6>Two-Factor Authentication</h6>
+                    <p>Add an extra layer of security to your account.</p>
+                </div>
+                <label class="toggle-switch">
+                    <input type="checkbox" name="tfa_enabled">
+                    <span class="toggle-slider"></span>
+                </label>
+            </div>
+        </div>
+
+        <!-- ── Section 4: Notification Settings ── -->
+        <div class="settings-card">
+            <div class="settings-section-heading">
+                <span class="settings-section-number">4</span>
+                Notification Settings
+            </div>
+
+            <div class="security-row">
+                <div class="security-row-left">
+                    <h6>Email Notifications</h6>
+                    <p>Receive important updates and alerts via email.</p>
+                </div>
+                <label class="toggle-switch">
+                    <input type="checkbox" name="email_notifications" checked>
+                    <span class="toggle-slider"></span>
+                </label>
+            </div>
+
+            <div class="security-row">
+                <div class="security-row-left">
+                    <h6>Task Reminders</h6>
+                    <p>Get reminded about tasks and deadlines.</p>
+                </div>
+                <label class="toggle-switch">
+                    <input type="checkbox" name="task_reminders" checked>
+                    <span class="toggle-slider"></span>
+                </label>
+            </div>
+        </div>
+
+        <!-- ── Action Bar ── -->
+        <div class="settings-action-bar">
+            <button type="submit" name="action" value="save_profile" class="btn-save">
+                Save Changes
+            </button>
+            <a href="{{ url_for('logout') }}" class="btn-logout">
+                <i class="bi bi-box-arrow-right"></i>
+                Log Out
+            </a>
+        </div>
+
+    </form>
+</div>
+
+<!-- ── Change Password Modal ── -->
+<div class="modal fade" id="changePasswordModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Change Password</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <form method="POST" action="{{ url_for('settings') }}" id="pw-form">
+                <div class="modal-body">
+                    <div id="pw-flash" class="flash-settings flash-danger d-none"></div>
+
+                    <div class="mb-3">
+                        <label class="form-label-settings">Current Password</label>
+                        <input type="password"
+                               name="current_password"
+                               id="current_password"
+                               class="form-input-settings"
+                               placeholder="Enter current password">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label-settings">New Password</label>
+                        <input type="password"
+                               name="new_password"
+                               id="new_password"
+                               class="form-input-settings"
+                               placeholder="At least 8 characters"
+                               oninput="checkStrength(this.value)">
+                        <div class="password-strength-bar">
+                            <div class="password-strength-fill" id="strength-fill"></div>
+                        </div>
+                        <div class="strength-label" id="strength-label"></div>
+                    </div>
+                    <div class="mb-1">
+                        <label class="form-label-settings">Confirm New Password</label>
+                        <input type="password"
+                               name="confirm_password"
+                               id="confirm_password"
+                               class="form-input-settings"
+                               placeholder="Repeat new password">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn-outline-secondary btn btn-sm" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn-save" onclick="submitPassword()">Update Password</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+{% endblock %}
+
+{% block extra_js %}
+<script>
+// ── Avatar preview ──
+document.getElementById('avatar-upload').addEventListener('change', function(e) {
+    var file = e.target.files[0];
+    if (!file) return;
+    var reader = new FileReader();
+    reader.onload = function(ev) {
+        var existing = document.getElementById('avatar-preview');
+        var initials = document.getElementById('avatar-initials');
+        if (existing) {
+            existing.src = ev.target.result;
+        } else if (initials) {
+            var img = document.createElement('img');
+            img.src = ev.target.result;
+            img.className = 'account-avatar';
+            img.id = 'avatar-preview';
+            initials.replaceWith(img);
+        }
+    };
+    reader.readAsDataURL(file);
+});
+
+// ── Password strength ──
+function checkStrength(val) {
+    var fill = document.getElementById('strength-fill');
+    var label = document.getElementById('strength-label');
+    if (!val) { fill.style.width = '0%'; label.textContent = ''; return; }
+    var score = 0;
+    if (val.length >= 8) score++;
+    if (/[A-Z]/.test(val)) score++;
+    if (/[0-9]/.test(val)) score++;
+    if (/[^A-Za-z0-9]/.test(val)) score++;
+    var levels = [
+        { w: '25%', c: '#e53e3e', t: 'Weak' },
+        { w: '50%', c: '#f59e0b', t: 'Fair' },
+        { w: '75%', c: '#3b82f6', t: 'Good' },
+        { w: '100%', c: '#1D9E75', t: 'Strong' }
+    ];
+    var lv = levels[score - 1] || levels[0];
+    fill.style.width = lv.w;
+    fill.style.background = lv.c;
+    label.textContent = lv.t;
+    label.style.color = lv.c;
+}
+
+// ── Password form submit ──
+function submitPassword() {
+    var cur = document.getElementById('current_password').value.trim();
+    var nw  = document.getElementById('new_password').value;
+    var cf  = document.getElementById('confirm_password').value;
+    var flash = document.getElementById('pw-flash');
+
+    flash.classList.add('d-none');
+
+    if (!cur) {
+        showPwFlash('Current password is required.'); return;
+    }
+    if (nw.length < 8) {
+        showPwFlash('New password must be at least 8 characters.'); return;
+    }
+    if (nw !== cf) {
+        showPwFlash('Passwords do not match.'); return;
+    }
+
+    // add hidden action field and submit
+    var input = document.createElement('input');
+    input.type = 'hidden';
+    input.name = 'action';
+    input.value = 'change_password';
+    document.getElementById('pw-form').appendChild(input);
+    document.getElementById('pw-form').submit();
+}
+
+function showPwFlash(msg) {
+    var flash = document.getElementById('pw-flash');
+    flash.textContent = msg;
+    flash.classList.remove('d-none');
+}
+</script>
+{% endblock %}

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -151,49 +151,6 @@ document.getElementById('avatar-upload').addEventListener('change', function(e) 
     reader.readAsDataURL(file);
 });
 
-function checkStrength(val) {
-    var fill = document.getElementById('strength-fill');
-    var label = document.getElementById('strength-label');
-    if (!val) { fill.style.width = '0%'; label.textContent = ''; return; }
-    var score = 0;
-    if (val.length >= 8) score++;
-    if (/[A-Z]/.test(val)) score++;
-    if (/[0-9]/.test(val)) score++;
-    if (/[^A-Za-z0-9]/.test(val)) score++;
-    var levels = [
-        { w: '25%', c: '#e53e3e', t: 'Weak' },
-        { w: '50%', c: '#f59e0b', t: 'Fair' },
-        { w: '75%', c: '#3b82f6', t: 'Good' },
-        { w: '100%', c: '#1D9E75', t: 'Strong' }
-    ];
-    var lv = levels[score - 1] || levels[0];
-    fill.style.width = lv.w;
-    fill.style.background = lv.c;
-    label.textContent = lv.t;
-    label.style.color = lv.c;
-}
 
-function submitPassword() {
-    var cur = document.getElementById('current_password').value.trim();
-    var nw  = document.getElementById('new_password').value;
-    var cf  = document.getElementById('confirm_password').value;
-    var flash = document.getElementById('pw-flash');
-    flash.classList.add('d-none');
-    if (!cur) { showPwFlash('Current password is required.'); return; }
-    if (nw.length < 8) { showPwFlash('New password must be at least 8 characters.'); return; }
-    if (nw !== cf) { showPwFlash('Passwords do not match.'); return; }
-    var input = document.createElement('input');
-    input.type = 'hidden';
-    input.name = 'action';
-    input.value = 'change_password';
-    document.getElementById('pw-form').appendChild(input);
-    document.getElementById('pw-form').submit();
-}
-
-function showPwFlash(msg) {
-    var flash = document.getElementById('pw-flash');
-    flash.textContent = msg;
-    flash.classList.remove('d-none');
-}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Description
Adds a full Settings page accessible from the sidebar, allowing users to manage their account credentials and preferences.
<img width="1372" height="873" alt="image" src="https://github.com/user-attachments/assets/db604b94-a321-4cb9-a0fb-fec480cf328d" />


## What was added
- Section 1: Account display (avatar, name, role, email, location) with Upload Photo button
- Section 2: Editable account info fields (Full Name, Email, Role, Location)
- Section 3: Login & Security – Change Password modal with validation + 2FA toggle (UI only)
- Section 4: Notification Settings – Email Notifications and Task Reminders toggles (UI only)
- Save Changes button saves Section 2 fields to DB
- Log Out button clears session and redirects to login
- Search bar hidden in topbar

## Key files changed
- `app/templates/settings.html` (new)
- `app/static/css/settings.css` (new)
- `app/__init__.py` (added `/settings` route with GET/POST)

## Testing
1. Run `python3 run.py`
2. Log in and navigate to Settings from sidebar
3. Edit account fields and click Save Changes – confirm data updates
4. Click Change Password – test validation (wrong current password, mismatch, too short)
5. Confirm Log Out redirects to login page

## Updates
- Fixed topbar: now uses shared `topbar.html` component (consistent with Dashboard, Sprints, Profile)
- Adjusted spacing between topbar and page content
- Separated Settings commits into own branch (`feature/settings-page-#35`)
- Simplified settings page to only show Account and Account Information sections (removed Change Password, 2FA, and Notification Settings per team feedback)
- Linked sidebar Settings item and topbar gear icon to `/settings` route
- Fixed LOG OUT colour in topbar to match other pages
<img width="1291" height="924" alt="image" src="https://github.com/user-attachments/assets/004b90c6-d453-4bc9-bb49-8477c886ed9b" />


Closes #35