### PR TITLE
Add backlog task search

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,7 +2,7 @@ import re
 from datetime import date, datetime
 
 import os
-from sqlalchemy import func
+from sqlalchemy import func, or_
 from werkzeug.utils import secure_filename
 from flask import Flask, app, flash, g, redirect, render_template, request, session, url_for
 from flask_sqlalchemy import SQLAlchemy
@@ -571,12 +571,28 @@ def create_app():
             return redirect(url_for("auth", mode="login"))
 
         project = Project.query.get_or_404(project_id)
-        tasks = Task.query.filter_by(project_id=project.id).all()
+        search_query = request.args.get("search", "").strip()
+
+        task_query = Task.query.filter_by(project_id=project.id)
+
+        # Let users search the backlog by the fields they can see on the page.
+        if search_query:
+            search_value = f"%{search_query.lower()}%"
+            task_query = task_query.filter(
+                or_(
+                    func.lower(Task.title).like(search_value),
+                    func.lower(func.coalesce(Task.task_code, "")).like(search_value),
+                    func.lower(func.coalesce(Task.description, "")).like(search_value),
+                )
+            )
+
+        tasks = task_query.order_by(Task.created_at.desc()).all()
 
         return render_template(
             "backlog.html",
             project=project,
-            tasks=tasks
+            tasks=tasks,
+            search_query=search_query
         )
     
     @app.route("/projects/<int:project_id>/assign-users", methods=["POST"])
@@ -644,12 +660,27 @@ def create_app():
         if g.user is None:
             return redirect(url_for("auth", mode="login"))
 
-        tasks = Task.query.order_by(Task.created_at.desc()).all()
+        search_query = request.args.get("search", "").strip()
+        task_query = Task.query
+
+        # The global backlog uses the same search rules as a project backlog.
+        if search_query:
+            search_value = f"%{search_query.lower()}%"
+            task_query = task_query.filter(
+                or_(
+                    func.lower(Task.title).like(search_value),
+                    func.lower(func.coalesce(Task.task_code, "")).like(search_value),
+                    func.lower(func.coalesce(Task.description, "")).like(search_value),
+                )
+            )
+
+        tasks = task_query.order_by(Task.created_at.desc()).all()
 
         return render_template(
           "backlog.html",
           project=None,
-          tasks=tasks
+          tasks=tasks,
+          search_query=search_query
         )
     
     # Route for user profile page

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -565,6 +565,20 @@ def create_app():
         search_query=search_query
         )
     
+    def apply_backlog_search(task_query, search_query):
+        # Search the task text fields shown in the backlog task details area.
+        if not search_query:
+            return task_query
+
+        search_value = search_query.lower()
+        return task_query.filter(
+            or_(
+                func.lower(Task.title).contains(search_value, autoescape=True),
+                func.lower(func.coalesce(Task.task_code, "")).contains(search_value, autoescape=True),
+                func.lower(func.coalesce(Task.description, "")).contains(search_value, autoescape=True),
+            )
+        )
+
     @app.route("/projects/<int:project_id>/backlog")
     def project_backlog(project_id):
         if g.user is None:
@@ -572,19 +586,10 @@ def create_app():
 
         project = Project.query.get_or_404(project_id)
         search_query = request.args.get("search", "").strip()
-
-        task_query = Task.query.filter_by(project_id=project.id)
-
-        # Let users search the backlog by the fields they can see on the page.
-        if search_query:
-            search_value = f"%{search_query.lower()}%"
-            task_query = task_query.filter(
-                or_(
-                    func.lower(Task.title).like(search_value),
-                    func.lower(func.coalesce(Task.task_code, "")).like(search_value),
-                    func.lower(func.coalesce(Task.description, "")).like(search_value),
-                )
-            )
+        base_task_query = Task.query.filter_by(project_id=project.id)
+        total_task_count = base_task_query.count()
+        total_unassigned_count = base_task_query.filter(Task.assignee_id.is_(None)).count()
+        task_query = apply_backlog_search(base_task_query, search_query)
 
         tasks = task_query.order_by(Task.created_at.desc()).all()
 
@@ -592,7 +597,9 @@ def create_app():
             "backlog.html",
             project=project,
             tasks=tasks,
-            search_query=search_query
+            search_query=search_query,
+            total_task_count=total_task_count,
+            total_unassigned_count=total_unassigned_count
         )
     
     @app.route("/projects/<int:project_id>/assign-users", methods=["POST"])
@@ -661,18 +668,10 @@ def create_app():
             return redirect(url_for("auth", mode="login"))
 
         search_query = request.args.get("search", "").strip()
-        task_query = Task.query
-
-        # The global backlog uses the same search rules as a project backlog.
-        if search_query:
-            search_value = f"%{search_query.lower()}%"
-            task_query = task_query.filter(
-                or_(
-                    func.lower(Task.title).like(search_value),
-                    func.lower(func.coalesce(Task.task_code, "")).like(search_value),
-                    func.lower(func.coalesce(Task.description, "")).like(search_value),
-                )
-            )
+        base_task_query = Task.query
+        total_task_count = base_task_query.count()
+        total_unassigned_count = base_task_query.filter(Task.assignee_id.is_(None)).count()
+        task_query = apply_backlog_search(base_task_query, search_query)
 
         tasks = task_query.order_by(Task.created_at.desc()).all()
 
@@ -680,7 +679,9 @@ def create_app():
           "backlog.html",
           project=None,
           tasks=tasks,
-          search_query=search_query
+          search_query=search_query,
+          total_task_count=total_task_count,
+          total_unassigned_count=total_unassigned_count
         )
     
     # Route for user profile page

--- a/app/static/css/dashboard_styles.css
+++ b/app/static/css/dashboard_styles.css
@@ -102,6 +102,24 @@ body {
   color: #94a3b8;
 }
 
+.search-submit-btn {
+  position: absolute;
+  top: 50%;
+  left: 12px;
+  transform: translateY(-50%);
+  border: 0;
+  background: transparent;
+  color: #94a3b8;
+  padding: 0;
+  line-height: 1;
+  z-index: 2;
+}
+
+.search-submit-btn i {
+  position: static;
+  transform: none;
+}
+
 .search-box .form-control {
   padding-left: 40px;
   height: 46px;

--- a/app/templates/backlog.html
+++ b/app/templates/backlog.html
@@ -15,6 +15,8 @@
 
 {# task data from backend route #}
 {% set task_items = tasks %}
+{% set search_query = search_query|default('') %}
+{% set backlog_url = url_for('project_backlog', project_id=project.id) if project else url_for('backlog') %}
 {% set total_tasks = task_items|length %}
 {% set unassigned_count = task_items|selectattr("assignee", "none")|list|length %}
 {% set project_name = project.name if project else 'No Project Selected' %}
@@ -72,6 +74,11 @@
     <a href="#" class="toolbar-action-btn">
       <i class="bi bi-sort-down me-1"></i> Sort
     </a>
+    {% if search_query %}
+    <a href="{{ backlog_url }}" class="toolbar-action-btn">
+      <i class="bi bi-x-circle me-1"></i> Clear "{{ search_query }}"
+    </a>
+    {% endif %}
   </div>
 </section>
 
@@ -164,7 +171,11 @@
         <tr>
           <td colspan="5" class="text-center py-5 text-muted">
             <i class="bi bi-inbox fs-2 d-block mb-2"></i>
-            No tasks in the backlog yet.
+            {% if search_query %}
+              No tasks matched "{{ search_query }}".
+            {% else %}
+              No tasks in the backlog yet.
+            {% endif %}
           </td>
         </tr>
         {% endfor %}
@@ -175,7 +186,11 @@
   {# Table footer: count + pagination #}
   <div class="backlog-table-footer">
     <span class="showing-label">
-      Showing {{ task_items | length }} of {{ total_tasks }} items
+      {% if search_query %}
+        Showing {{ task_items | length }} matching items
+      {% else %}
+        Showing {{ task_items | length }} of {{ total_tasks }} items
+      {% endif %}
     </span>
     <div class="pagination-btns">
       <a href="#" class="page-btn">Previous</a>
@@ -183,5 +198,34 @@
     </div>
   </div>
 </section>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    const searchInput = document.querySelector(".search-box input");
+    const backlogUrl = "{{ backlog_url }}";
+    const currentSearch = {{ search_query|tojson }};
+
+    if (!searchInput) {
+      return;
+    }
+
+    searchInput.value = currentSearch;
+
+    searchInput.addEventListener("keydown", function (event) {
+      if (event.key !== "Enter") {
+        return;
+      }
+
+      event.preventDefault();
+      const nextSearch = searchInput.value.trim();
+
+      if (nextSearch) {
+        window.location.href = backlogUrl + "?search=" + encodeURIComponent(nextSearch);
+      } else {
+        window.location.href = backlogUrl;
+      }
+    });
+  });
+</script>
 
 {% endblock %}

--- a/app/templates/backlog.html
+++ b/app/templates/backlog.html
@@ -11,14 +11,16 @@
 {# Topbar #}
 {% set topbar_title = 'Backlog' %}
 {% set topbar_search_placeholder = 'Search tasks...' %}
+{% set search_query = search_query|default('') %}
+{% set backlog_url = url_for('project_backlog', project_id=project.id) if project else url_for('backlog') %}
+{% set topbar_search_action = backlog_url %}
+{% set topbar_search_value = search_query %}
 {% include "components/topbar.html" %}
 
 {# task data from backend route #}
 {% set task_items = tasks %}
-{% set search_query = search_query|default('') %}
-{% set backlog_url = url_for('project_backlog', project_id=project.id) if project else url_for('backlog') %}
-{% set total_tasks = task_items|length %}
-{% set unassigned_count = task_items|selectattr("assignee", "none")|list|length %}
+{% set total_tasks = total_task_count|default(task_items|length) %}
+{% set unassigned_count = total_unassigned_count|default(task_items|selectattr("assignee", "none")|list|length) %}
 {% set project_name = project.name if project else 'No Project Selected' %}
 
 {# Header Card #}
@@ -198,34 +200,5 @@
     </div>
   </div>
 </section>
-
-<script>
-  document.addEventListener("DOMContentLoaded", function () {
-    const searchInput = document.querySelector(".search-box input");
-    const backlogUrl = "{{ backlog_url }}";
-    const currentSearch = {{ search_query|tojson }};
-
-    if (!searchInput) {
-      return;
-    }
-
-    searchInput.value = currentSearch;
-
-    searchInput.addEventListener("keydown", function (event) {
-      if (event.key !== "Enter") {
-        return;
-      }
-
-      event.preventDefault();
-      const nextSearch = searchInput.value.trim();
-
-      if (nextSearch) {
-        window.location.href = backlogUrl + "?search=" + encodeURIComponent(nextSearch);
-      } else {
-        window.location.href = backlogUrl;
-      }
-    });
-  });
-</script>
 
 {% endblock %}

--- a/app/templates/components/topbar.html
+++ b/app/templates/components/topbar.html
@@ -4,6 +4,21 @@
     <h3 class="page-title mb-0">{{ topbar_title }}</h3>
     {% endif %}
 
+    {% if topbar_search_action %}
+    <form method="GET" action="{{ topbar_search_action }}" class="search-box {{ topbar_search_class | default('') }}">
+      <button type="submit" class="search-submit-btn" aria-label="Search">
+        <i class="bi bi-search"></i>
+      </button>
+      <input
+        type="text"
+        name="{{ topbar_search_name | default('search') }}"
+        value="{{ topbar_search_value | default('') }}"
+        class="form-control"
+        placeholder="{{ topbar_search_placeholder | default('Search...') }}"
+        title="Type to search and press Enter"
+      />
+    </form>
+    {% else %}
     <div class="search-box {{ topbar_search_class | default('') }}">
       <i class="bi bi-search"></i>
       <input
@@ -13,6 +28,7 @@
         title="Type to search and press Enter"
       />
     </div>
+    {% endif %}
   </div>
 
   <div class="topbar-right d-flex align-items-center gap-3">


### PR DESCRIPTION
**Description**

This PR adds search support to the backlog page so tasks can be filtered from the top search box.

**What was added**

updated the backlog routes to read the search query from the URL
filtered tasks by title, task code, and description
kept the search text visible after searching
added a clear search option when results are filtered
updated the empty state message when no matching tasks are found

**Key files changed**

app/__init__.py
app/templates/backlog.html

**Testing**

Tested manually by searching tasks from the backlog page and clearing the search to show all tasks again.

Closes #37