### PR TITLE
Add create and view task modals

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -558,10 +558,20 @@ def create_app():
         project = Project.query.get_or_404(project_id)
         tasks = Task.query.filter_by(project_id=project.id).all()
 
+        users = User.query.filter_by(is_active=True)\
+            .order_by(User.full_name.asc())\
+            .all()
+
+        sprints = Sprint.query.filter_by(project_id=project.id)\
+            .order_by(Sprint.start_date.asc())\
+            .all()
+
         return render_template(
             "backlog.html",
             project=project,
-            tasks=tasks
+            tasks=tasks,
+            users=users,
+            sprints=sprints
         )
     
     @app.route("/projects/<int:project_id>/assign-users", methods=["POST"])
@@ -622,20 +632,75 @@ def create_app():
         flash("Project deleted successfully.", "success")
         return redirect(url_for("project"))
 
-    #Route for backlog page
-    
+    # Route for backlog page
     @app.route("/backlog")
     def backlog():
         if g.user is None:
             return redirect(url_for("auth", mode="login"))
 
         tasks = Task.query.order_by(Task.created_at.desc()).all()
+        projects = Project.query.filter_by(status="active").order_by(Project.name.asc()).all()
+        users = User.query.filter_by(is_active=True).order_by(User.full_name.asc()).all()
+        sprints = Sprint.query.order_by(Sprint.start_date.asc()).all()
 
         return render_template(
-          "backlog.html",
-          project=None,
-          tasks=tasks
+            "backlog.html",
+            project=None,
+            tasks=tasks,
+            projects=projects,
+            users=users,
+            sprints=sprints
         )
+    
+    @app.route("/tasks/create", methods=["POST"])
+    def create_task():
+        if g.user is None:
+            return redirect(url_for("auth", mode="login"))
+
+        title = request.form.get("title", "").strip()
+        description = request.form.get("description", "").strip()
+        project_id = request.form.get("project_id")
+        sprint_id = request.form.get("sprint_id")
+        assignee_id = request.form.get("assignee_id")
+        priority = request.form.get("priority", "medium")
+        status = request.form.get("status", "backlog")
+        story_points_raw = request.form.get("story_points", "0")
+        due_date_raw = request.form.get("due_date", "")
+
+        if not title or not project_id:
+            flash("Task title and project are required.", "error")
+            return redirect(request.referrer or url_for("backlog"))
+
+        try:
+            story_points = int(story_points_raw)
+        except ValueError:
+            story_points = 0
+
+        due_date = None
+        if due_date_raw:
+            try:
+                due_date = date.fromisoformat(due_date_raw)
+            except ValueError:
+                due_date = None
+
+        task = Task(
+            title=title,
+            description=description,
+            project_id=int(project_id),
+            sprint_id=int(sprint_id) if sprint_id else None,
+            assignee_id=int(assignee_id) if assignee_id else None,
+            created_by=g.user.id,
+            priority=priority,
+            status=status,
+            story_points=story_points,
+            due_date=due_date,
+        )
+
+        db.session.add(task)
+        db.session.commit()
+
+        flash("Task created successfully.", "success")
+        return redirect(request.referrer or url_for("backlog"))
     
     # Route for user profile page
     @app.route("/profile", methods=["GET", "POST"])

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -749,7 +749,7 @@ def create_app():
             .all()
         )
         task_query = apply_backlog_search(base_task_query, search_query)
-                task_query, backlog_options = apply_backlog_options(task_query)
+        task_query, backlog_options = apply_backlog_options(task_query)
         tasks = task_query.all()
 
         projects = Project.query.filter_by(status="active").order_by(Project.name.asc()).all()
@@ -818,6 +818,54 @@ def create_app():
         db.session.commit()
 
         flash("Task created successfully.", "success")
+        return redirect(request.referrer or url_for("backlog"))
+
+    @app.route("/tasks/<int:task_id>/edit", methods=["POST"])
+    def edit_task(task_id):
+        if g.user is None:
+            return redirect(url_for("auth", mode="login"))
+
+        task = Task.query.get_or_404(task_id)
+
+        title = request.form.get("title", "").strip()
+        description = request.form.get("description", "").strip()
+        project_id = request.form.get("project_id")
+        sprint_id = request.form.get("sprint_id")
+        assignee_id = request.form.get("assignee_id")
+        priority = request.form.get("priority", "medium")
+        status = request.form.get("status", "backlog")
+        story_points_raw = request.form.get("story_points", "0")
+        due_date_raw = request.form.get("due_date", "")
+
+        if not title or not project_id:
+            flash("Task title and project are required.", "error")
+            return redirect(request.referrer or url_for("backlog"))
+
+        try:
+            story_points = int(story_points_raw)
+        except ValueError:
+            story_points = 0
+
+        due_date = None
+        if due_date_raw:
+            try:
+                due_date = date.fromisoformat(due_date_raw)
+            except ValueError:
+                due_date = None
+
+        task.title = title
+        task.description = description
+        task.project_id = int(project_id)
+        task.sprint_id = int(sprint_id) if sprint_id else None
+        task.assignee_id = int(assignee_id) if assignee_id else None
+        task.priority = priority
+        task.status = status
+        task.story_points = story_points
+        task.due_date = due_date
+
+        db.session.commit()
+
+        flash("Task updated successfully.", "success")
         return redirect(request.referrer or url_for("backlog"))
     
     # Route for user profile page

--- a/app/static/css/backlog_styles.css
+++ b/app/static/css/backlog_styles.css
@@ -83,7 +83,7 @@
 
 .backlog-create-btn {
   background-color: #1D9E75;
-  border-color: #1D9E75;
+  border: none;
   color: #ffffff;
   border-radius: 12px;
   padding: 14px 22px;
@@ -486,5 +486,175 @@
     flex-direction: column;
     align-items: center;
     text-align: center;
+  }
+}
+
+/* Create Task modal */
+.project-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(4px);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 999;
+}
+
+.project-modal-backdrop.show {
+  display: flex;
+}
+
+.project-modal-card {
+  width: min(520px, calc(100% - 32px));
+  background: #ffffff;
+  border-radius: 18px;
+  padding: 28px;
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.22);
+  border-bottom: 5px solid #059669;
+}
+
+.project-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.project-modal-header h2 {
+  font-size: 20px;
+  font-weight: 700;
+  color: #111827;
+  margin: 0;
+}
+
+.project-modal-close {
+  border: none;
+  background: transparent;
+  color: #6b7280;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+.project-form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.project-form-group {
+  margin-bottom: 18px;
+}
+
+.project-form-group label {
+  display: block;
+  font-size: 11px;
+  font-weight: 700;
+  color: #6b7280;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.project-form-group input,
+.project-form-group textarea,
+.project-form-group select {
+  width: 100%;
+  border: none;
+  background: #eef0f2;
+  border-radius: 6px;
+  padding: 13px 14px;
+  font-size: 14px;
+  color: #111827;
+  outline: none;
+}
+
+.project-form-group textarea {
+  min-height: 96px;
+  resize: vertical;
+}
+
+.project-form-group input:focus,
+.project-form-group textarea:focus,
+.project-form-group select:focus {
+  box-shadow: 0 0 0 3px rgba(5, 150, 105, 0.16);
+  background: #f8fafc;
+}
+
+.project-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 14px;
+  margin-top: 8px;
+}
+
+.project-cancel-btn,
+.project-submit-btn {
+  border: none;
+  border-radius: 8px;
+  padding: 11px 18px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.project-cancel-btn {
+  background: transparent;
+  color: #374151;
+}
+
+.project-submit-btn {
+  background: #1D9E75;
+  color: #ffffff;
+  box-shadow: 0 8px 18px rgba(29, 158, 117, 0.24);
+}
+
+.project-submit-btn:hover {
+  background: #157a5a;
+}
+
+/* View Task modal */
+.task-view-meta {
+  font-size: 13px;
+  color: #94a3b8;
+  margin-top: 4px;
+}
+
+.task-view-description {
+  background: #f8fafc;
+  border-radius: 10px;
+  padding: 14px 16px;
+  color: #475569;
+  line-height: 1.6;
+  margin-bottom: 18px;
+}
+
+.task-view-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.task-view-item {
+  background: #eef0f2;
+  border-radius: 10px;
+  padding: 13px 14px;
+}
+
+.task-view-item span {
+  display: block;
+  font-size: 11px;
+  font-weight: 700;
+  color: #6b7280;
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+
+.task-view-item strong {
+  font-size: 15px;
+  color: #111827;
+}
+
+@media (max-width: 560px) {
+  .task-view-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/app/templates/backlog.html
+++ b/app/templates/backlog.html
@@ -26,33 +26,31 @@
       <a href="{{ url_for('project') }}">Projects</a>
       <span class="breadcrumb-sep">/</span>
       <span>{{ project_name }}</span>
-    </nav>
-    <h1 class="backlog-hero-title">Project Backlog</h1>
-    <p class="backlog-hero-text">
-      Manage and prioritize tasks for the upcoming development cycles.
-      Drag to reorder or use filters to focus on specific workstreams.
-    </p>
-  </div>
-
-  <div class="backlog-hero-right">
-   
-    <div class="backlog-stat">
-      <span class="backlog-stat-label">TOTAL<br>TASKS</span>
-      <span class="backlog-stat-number">{{ total_tasks }}</span>
-    </div>
-
-   
-    <div class="backlog-stat">
-      <span class="backlog-stat-label">UNASSIGNED</span>
-      <span class="backlog-stat-number">{{ unassigned_count }}</span>
-    </div>
-
-   
-    <a href="#" class="backlog-create-btn">
-      <i class="bi bi-plus-lg me-1"></i> Create<br>Task
-    </a>
-  </div>
-</section>
+      </nav>
+      <h1 class="backlog-hero-title">Project Backlog</h1>
+      <p class="backlog-hero-text">
+        Manage and prioritize tasks for the upcoming development cycles.
+        Drag to reorder or use filters to focus on specific workstreams.
+      </p>
+      </div>
+      
+      <div class="backlog-hero-right">
+      
+        <div class="backlog-stat">
+          <span class="backlog-stat-label">TOTAL<br>TASKS</span>
+          <span class="backlog-stat-number">{{ total_tasks }}</span>
+        </div>
+        <div class="backlog-stat">
+          <span class="backlog-stat-label">UNASSIGNED</span>
+          <span class="backlog-stat-number">{{ unassigned_count }}</span>
+        </div>
+      
+      
+        <button type="button" class="backlog-create-btn" id="openTaskModal">
+          <i class="bi bi-plus-lg me-1"></i> Create<br>Task
+        </button>
+      </div>
+      </section>
 
 {# Toolbar #}
 <section class="backlog-toolbar">
@@ -103,12 +101,14 @@
             {% set t_sprint = task.sprint.name if task.sprint else 'TBD' %}
         
             <tr class="backlog-row">
-        
-                <td class="task-details-cell">
-                    <a href="#" class="task-title-link">{{ t_title }}</a>
-                    <span class="task-meta">{{ t_id }} &bull; {{ t_created }}</span>
-                </td>
-          <td>
+              <td class="task-details-cell">
+                <button type="button" class="task-title-link border-0 bg-transparent p-0 text-start open-view-task-modal"
+                  data-task-id="{{ task.id }}">
+                  {{ t_title }}
+                </button>
+                <span class="task-meta">{{ t_id }} &bull; {{ t_created }}</span>
+              </td>
+              <td>
             {% if t_priority == 'high' %}
               <span class="priority-badge priority-high">
                 <i class="bi bi-circle-fill me-1"></i> HIGH
@@ -172,6 +172,79 @@
     </table>
   </div>
 
+    {# View Task Modals #}
+{% for task in task_items %}
+<div class="project-modal-backdrop" id="viewTaskModal{{ task.id }}">
+  <div class="project-modal-card">
+    <div class="project-modal-header">
+      <div>
+        <h2>{{ task.title }}</h2>
+        <p class="task-view-meta mb-0">
+          {{ task.task_code if task.task_code else 'Task #' ~ task.id }}
+          • Created {{ task.created_at.strftime('%b %d, %Y') }}
+        </p>
+      </div>
+
+      <button type="button" class="project-modal-close view-task-close" data-task-id="{{ task.id }}">
+        <i class="bi bi-x-lg"></i>
+      </button>
+    </div>
+
+    <div class="task-view-description">
+      {{ task.description or 'No description added.' }}
+    </div>
+
+    <div class="task-view-grid">
+      <div class="task-view-item">
+        <span>Project</span>
+        <strong>{{ task.project.name if task.project else 'N/A' }}</strong>
+      </div>
+
+      <div class="task-view-item">
+        <span>Sprint</span>
+        <strong>{{ task.sprint.name if task.sprint else 'TBD' }}</strong>
+      </div>
+
+      <div class="task-view-item">
+        <span>Assignee</span>
+        <strong>{{ task.assignee.full_name if task.assignee else 'Unassigned' }}</strong>
+      </div>
+
+      <div class="task-view-item">
+        <span>Priority</span>
+        <strong>{{ task.priority|title }}</strong>
+      </div>
+
+      <div class="task-view-item">
+        <span>Status</span>
+        <strong>{{ task.status.replace('_', ' ')|title }}</strong>
+      </div>
+
+      <div class="task-view-item">
+        <span>Story Points</span>
+        <strong>{{ task.story_points }}</strong>
+      </div>
+
+      <div class="task-view-item">
+        <span>Due Date</span>
+        <strong>{{ task.due_date.strftime('%b %d, %Y') if task.due_date else 'No due date' }}</strong>
+      </div>
+
+      <div class="task-view-item">
+        <span>Created By</span>
+        <strong>{{ task.creator.full_name if task.creator else 'Unknown' }}</strong>
+      </div>
+    </div>
+
+    <div class="project-modal-actions">
+      <button type="button" class="project-cancel-btn view-task-close" data-task-id="{{ task.id }}">
+        Close
+      </button>
+    </div>
+  </div>
+</div>
+{% endfor %}
+
   {# Table footer: count + pagination #}
   <div class="backlog-table-footer">
     <span class="showing-label">
@@ -183,5 +256,178 @@
     </div>
   </div>
 </section>
+
+<div class="project-modal-backdrop" id="taskModal">
+  <div class="project-modal-card">
+    <div class="project-modal-header">
+      <h2>Create Task</h2>
+      <button type="button" class="project-modal-close" id="closeTaskModal">
+        <i class="bi bi-x-lg"></i>
+      </button>
+    </div>
+
+    <form method="POST" action="{{ url_for('create_task') }}">
+      {% if project %}
+        <input type="hidden" name="project_id" value="{{ project.id }}">
+      {% else %}
+        <div class="project-form-group">
+          <label for="taskProject">Project</label>
+          <select id="taskProject" name="project_id" required>
+            <option value="">Select project</option>
+            {% for project_item in projects %}
+              <option value="{{ project_item.id }}">{{ project_item.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      {% endif %}
+
+      <div class="project-form-group">
+        <label for="taskTitle">Task Title</label>
+        <input
+          type="text"
+          id="taskTitle"
+          name="title"
+          placeholder="e.g. Implement user authentication"
+          required
+        />
+      </div>
+
+      <div class="project-form-group">
+        <label for="taskDescription">Task Description</label>
+        <textarea
+          id="taskDescription"
+          name="description"
+          placeholder="Briefly describe the task..."
+        ></textarea>
+      </div>
+
+      <div class="project-form-row">
+        <div class="project-form-group">
+          <label for="taskPriority">Priority</label>
+          <select id="taskPriority" name="priority">
+            <option value="low">Low</option>
+            <option value="medium" selected>Medium</option>
+            <option value="high">High</option>
+          </select>
+        </div>
+
+        <div class="project-form-group">
+          <label for="taskStatus">Status</label>
+          <select id="taskStatus" name="status">
+            <option value="backlog" selected>Backlog</option>
+            <option value="todo">Todo</option>
+            <option value="in_progress">In Progress</option>
+            <option value="done">Done</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="project-form-row">
+        <div class="project-form-group">
+          <label for="taskAssignee">Assignee</label>
+          <select id="taskAssignee" name="assignee_id">
+            <option value="">Unassigned</option>
+            {% for user in users %}
+              <option value="{{ user.id }}">{{ user.full_name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+
+        <div class="project-form-group">
+          <label for="taskSprint">Sprint</label>
+          <select id="taskSprint" name="sprint_id">
+            <option value="">No sprint</option>
+            {% for sprint in sprints %}
+              <option value="{{ sprint.id }}">{{ sprint.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+
+      <div class="project-form-row">
+        <div class="project-form-group">
+          <label for="taskStoryPoints">Story Points</label>
+          <input
+            type="number"
+            id="taskStoryPoints"
+            name="story_points"
+            min="0"
+            value="0"
+          />
+        </div>
+
+        <div class="project-form-group">
+          <label for="taskDueDate">Due Date</label>
+          <input type="date" id="taskDueDate" name="due_date" />
+        </div>
+      </div>
+
+      <div class="project-modal-actions">
+        <button type="button" class="project-cancel-btn" id="cancelTaskModal">
+          Cancel
+        </button>
+        <button type="submit" class="project-submit-btn">Create Task</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<script>
+  const taskModal = document.getElementById("taskModal");
+  const openTaskModal = document.getElementById("openTaskModal");
+  const closeTaskModal = document.getElementById("closeTaskModal");
+  const cancelTaskModal = document.getElementById("cancelTaskModal");
+
+  function openTaskModalPopup() {
+    taskModal.classList.add("show");
+  }
+
+  function closeTaskModalPopup() {
+    taskModal.classList.remove("show");
+  }
+
+  openTaskModal.addEventListener("click", openTaskModalPopup);
+  closeTaskModal.addEventListener("click", closeTaskModalPopup);
+  cancelTaskModal.addEventListener("click", closeTaskModalPopup);
+
+  taskModal.addEventListener("click", function (event) {
+    if (event.target === taskModal) {
+      closeTaskModalPopup();
+    }
+  });
+
+  document.addEventListener("keydown", function (event) {
+    if (event.key === "Escape") {
+      closeTaskModalPopup();
+    }
+  });
+
+    const openViewTaskButtons = document.querySelectorAll(".open-view-task-modal");
+  const closeViewTaskButtons = document.querySelectorAll(".view-task-close");
+
+  openViewTaskButtons.forEach(function (button) {
+    button.addEventListener("click", function () {
+      const taskId = button.getAttribute("data-task-id");
+      const modal = document.getElementById("viewTaskModal" + taskId);
+      modal.classList.add("show");
+    });
+  });
+
+  closeViewTaskButtons.forEach(function (button) {
+    button.addEventListener("click", function () {
+      const taskId = button.getAttribute("data-task-id");
+      const modal = document.getElementById("viewTaskModal" + taskId);
+      modal.classList.remove("show");
+    });
+  });
+
+  document.querySelectorAll("[id^='viewTaskModal']").forEach(function (modal) {
+    modal.addEventListener("click", function (event) {
+      if (event.target === modal) {
+        modal.classList.remove("show");
+      }
+    });
+  });
+</script>
 
 {% endblock %}

--- a/app/templates/backlog.html
+++ b/app/templates/backlog.html
@@ -36,31 +36,31 @@
       <a href="{{ url_for('project') }}">Projects</a>
       <span class="breadcrumb-sep">/</span>
       <span>{{ project_name }}</span>
-      </nav>
-      <h1 class="backlog-hero-title">Project Backlog</h1>
-      <p class="backlog-hero-text">
-        Manage and prioritize tasks for the upcoming development cycles.
-        Drag to reorder or use filters to focus on specific workstreams.
-      </p>
-      </div>
-      
-      <div class="backlog-hero-right">
-      
-        <div class="backlog-stat">
-          <span class="backlog-stat-label">TOTAL<br>TASKS</span>
-          <span class="backlog-stat-number">{{ total_tasks }}</span>
-        </div>
-        <div class="backlog-stat">
-          <span class="backlog-stat-label">UNASSIGNED</span>
-          <span class="backlog-stat-number">{{ unassigned_count }}</span>
-        </div>
-      
-      
-        <button type="button" class="backlog-create-btn" id="openTaskModal">
-          <i class="bi bi-plus-lg me-1"></i> Create<br>Task
-        </button>
-      </div>
-      </section>
+    </nav>
+    <h1 class="backlog-hero-title">Project Backlog</h1>
+    <p class="backlog-hero-text">
+      Manage and prioritize tasks for the upcoming development cycles.
+      Drag to reorder or use filters to focus on specific workstreams.
+    </p>
+  </div>
+
+  <div class="backlog-hero-right">
+
+    <div class="backlog-stat">
+      <span class="backlog-stat-label">TOTAL<br>TASKS</span>
+      <span class="backlog-stat-number">{{ total_tasks }}</span>
+    </div>
+    <div class="backlog-stat">
+      <span class="backlog-stat-label">UNASSIGNED</span>
+      <span class="backlog-stat-number">{{ unassigned_count }}</span>
+    </div>
+
+
+    <button type="button" class="backlog-create-btn" id="openTaskModal">
+      <i class="bi bi-plus-lg me-1"></i> Create<br>Task
+    </button>
+  </div>
+</section>
 
 {# Toolbar #}
 <section class="backlog-toolbar">
@@ -150,78 +150,78 @@
           <th>PRIORITY</th>
           <th>STATUS</th>
           <th>ASSIGNEE</th>
-        <th>SPRINT</th>
+          <th>SPRINT</th>
         </tr>
-        </thead>
-        <tbody>
-            {% for task in task_items %}
-        
-            {# read task fields #}
-            {% set t_id = task.task_code if task.task_code else task.id %}
-            {% set t_title = task.title %}
-            {% set t_created = task.created_at.strftime('%b %d') %}
-            {% set t_priority = task.priority %}
-            {% set t_status = task.status %}
-            {% set t_label = t_status.replace('_', ' ')|title %}
-            {% set t_assignee = task.assignee.full_name if task.assignee else None %}
-            {% set t_initials = task.assignee.full_name[:2]|upper if task.assignee else None %}
-            {% set t_sprint = task.sprint.name if task.sprint else 'TBD' %}
-        
-            <tr class="backlog-row">
-              <td class="task-details-cell">
-                <button type="button" class="task-title-link border-0 bg-transparent p-0 text-start open-view-task-modal"
-                  data-task-id="{{ task.id }}">
-                  {{ t_title }}
-                </button>
-                <span class="task-meta">{{ t_id }} &bull; {{ t_created }}</span>
-              </td>
-              <td>
+      </thead>
+      <tbody>
+        {% for task in task_items %}
+
+        {# read task fields #}
+        {% set t_id = task.task_code if task.task_code else task.id %}
+        {% set t_title = task.title %}
+        {% set t_created = task.created_at.strftime('%b %d') %}
+        {% set t_priority = task.priority %}
+        {% set t_status = task.status %}
+        {% set t_label = t_status.replace('_', ' ')|title %}
+        {% set t_assignee = task.assignee.full_name if task.assignee else None %}
+        {% set t_initials = task.assignee.full_name[:2]|upper if task.assignee else None %}
+        {% set t_sprint = task.sprint.name if task.sprint else 'TBD' %}
+
+        <tr class="backlog-row">
+          <td class="task-details-cell">
+            <button type="button" class="task-title-link border-0 bg-transparent p-0 text-start open-view-task-modal"
+              data-task-id="{{ task.id }}">
+              {{ t_title }}
+            </button>
+            <span class="task-meta">{{ t_id }} &bull; {{ t_created }}</span>
+          </td>
+          <td>
             {% if t_priority == 'high' %}
-              <span class="priority-badge priority-high">
-                <i class="bi bi-circle-fill me-1"></i> HIGH
-              </span>
+            <span class="priority-badge priority-high">
+              <i class="bi bi-circle-fill me-1"></i> HIGH
+            </span>
             {% elif t_priority == 'medium' %}
-              <span class="priority-badge priority-medium">
-                <i class="bi bi-circle-fill me-1"></i> MEDIUM
-              </span>
+            <span class="priority-badge priority-medium">
+              <i class="bi bi-circle-fill me-1"></i> MEDIUM
+            </span>
             {% else %}
-              <span class="priority-badge priority-low">
-                <i class="bi bi-circle-fill me-1"></i> LOW
-              </span>
+            <span class="priority-badge priority-low">
+              <i class="bi bi-circle-fill me-1"></i> LOW
+            </span>
             {% endif %}
           </td>
 
-         
+
           <td>
             {% if t_status == 'in_progress' %}
-              <span class="status-badge in-progress">{{ t_label }}</span>
+            <span class="status-badge in-progress">{{ t_label }}</span>
             {% elif t_status == 'blocker' %}
-              <span class="status-badge blocker">{{ t_label }}</span>
+            <span class="status-badge blocker">{{ t_label }}</span>
             {% else %}
-              <span class="status-badge todo">{{ t_label }}</span>
+            <span class="status-badge todo">{{ t_label }}</span>
             {% endif %}
           </td>
 
-          
+
           <td>
             {% if t_assignee %}
-              <div class="assignee-cell">
-                <span class="assignee-avatar">{{ t_initials }}</span>
-                <span class="assignee-name">{{ t_assignee }}</span>
-              </div>
+            <div class="assignee-cell">
+              <span class="assignee-avatar">{{ t_initials }}</span>
+              <span class="assignee-name">{{ t_assignee }}</span>
+            </div>
             {% else %}
-              <a href="#" class="assign-btn">
-                <i class="bi bi-person-plus me-1"></i> Assign
-              </a>
+            <a href="#" class="assign-btn">
+              <i class="bi bi-person-plus me-1"></i> Assign
+            </a>
             {% endif %}
           </td>
 
-          
+
           <td>
             {% if t_sprint and t_sprint != 'TBD' %}
-              <a href="#" class="sprint-link">{{ t_sprint }}</a>
+            <a href="#" class="sprint-link">{{ t_sprint }}</a>
             {% else %}
-              <span class="sprint-tbd">TBD</span>
+            <span class="sprint-tbd">TBD</span>
             {% endif %}
           </td>
         </tr>
@@ -238,7 +238,7 @@
             {% elif has_active_options %}
               No tasks matched the selected filters.
             {% else %}
-              No tasks in the backlog yet.
+            No tasks in the backlog yet.
             {% endif %}
           </td>
         </tr>
@@ -247,78 +247,82 @@
     </table>
   </div>
 
-    {# View Task Modals #}
-{% for task in task_items %}
-<div class="project-modal-backdrop" id="viewTaskModal{{ task.id }}">
-  <div class="project-modal-card">
-    <div class="project-modal-header">
-      <div>
-        <h2>{{ task.title }}</h2>
-        <p class="task-view-meta mb-0">
-          {{ task.task_code if task.task_code else 'Task #' ~ task.id }}
-          • Created {{ task.created_at.strftime('%b %d, %Y') }}
-        </p>
+  {# View Task Modals #}
+  {% for task in task_items %}
+  <div class="project-modal-backdrop" id="viewTaskModal{{ task.id }}">
+    <div class="project-modal-card">
+      <div class="project-modal-header">
+        <div>
+          <h2>{{ task.title }}</h2>
+          <p class="task-view-meta mb-0">
+            {{ task.task_code if task.task_code else 'Task #' ~ task.id }}
+            • Created {{ task.created_at.strftime('%b %d, %Y') }}
+          </p>
+        </div>
+
+        <button type="button" class="project-modal-close view-task-close" data-task-id="{{ task.id }}">
+          <i class="bi bi-x-lg"></i>
+        </button>
       </div>
 
-      <button type="button" class="project-modal-close view-task-close" data-task-id="{{ task.id }}">
-        <i class="bi bi-x-lg"></i>
-      </button>
-    </div>
-
-    <div class="task-view-description">
-      {{ task.description or 'No description added.' }}
-    </div>
-
-    <div class="task-view-grid">
-      <div class="task-view-item">
-        <span>Project</span>
-        <strong>{{ task.project.name if task.project else 'N/A' }}</strong>
+      <div class="task-view-description">
+        {{ task.description or 'No description added.' }}
       </div>
 
-      <div class="task-view-item">
-        <span>Sprint</span>
-        <strong>{{ task.sprint.name if task.sprint else 'TBD' }}</strong>
-      </div>
+      <div class="task-view-grid">
+        <div class="task-view-item">
+          <span>Project</span>
+          <strong>{{ task.project.name if task.project else 'N/A' }}</strong>
+        </div>
 
-      <div class="task-view-item">
-        <span>Assignee</span>
-        <strong>{{ task.assignee.full_name if task.assignee else 'Unassigned' }}</strong>
-      </div>
+        <div class="task-view-item">
+          <span>Sprint</span>
+          <strong>{{ task.sprint.name if task.sprint else 'TBD' }}</strong>
+        </div>
 
-      <div class="task-view-item">
-        <span>Priority</span>
-        <strong>{{ task.priority|title }}</strong>
-      </div>
+        <div class="task-view-item">
+          <span>Assignee</span>
+          <strong>{{ task.assignee.full_name if task.assignee else 'Unassigned' }}</strong>
+        </div>
 
-      <div class="task-view-item">
-        <span>Status</span>
-        <strong>{{ task.status.replace('_', ' ')|title }}</strong>
-      </div>
+        <div class="task-view-item">
+          <span>Priority</span>
+          <strong>{{ task.priority|title }}</strong>
+        </div>
 
-      <div class="task-view-item">
-        <span>Story Points</span>
+        <div class="task-view-item">
+          <span>Status</span>
+          <strong>{{ task.status.replace('_', ' ')|title }}</strong>
+        </div>
+
+        <div class="task-view-item">
+          <span>Story Points</span>
         <strong>{{ task.story_points }}</strong>
+        </div>
+
+        <div class="task-view-item">
+          <span>Due Date</span>
+          <strong>{{ task.due_date.strftime('%b %d, %Y') if task.due_date else 'No due date' }}</strong>
+        </div>
+
+        <div class="task-view-item">
+          <span>Created By</span>
+          <strong>{{ task.creator.full_name if task.creator else 'Unknown' }}</strong>
+        </div>
       </div>
 
-      <div class="task-view-item">
-        <span>Due Date</span>
-        <strong>{{ task.due_date.strftime('%b %d, %Y') if task.due_date else 'No due date' }}</strong>
-      </div>
+      <div class="project-modal-actions">
+        <button type="button" class="project-cancel-btn view-task-close" data-task-id="{{ task.id }}">
+          Close
+        </button>
 
-      <div class="task-view-item">
-        <span>Created By</span>
-        <strong>{{ task.creator.full_name if task.creator else 'Unknown' }}</strong>
+        <button type="button" class="project-submit-btn open-edit-task-modal" data-task-id="{{ task.id }}">
+          Edit Task
+        </button>
       </div>
-    </div>
-
-    <div class="project-modal-actions">
-      <button type="button" class="project-cancel-btn view-task-close" data-task-id="{{ task.id }}">
-        Close
-      </button>
     </div>
   </div>
-</div>
-{% endfor %}
+  {% endfor %}
 
   {# Table footer: count + pagination #}
   <div class="backlog-table-footer">
@@ -330,7 +334,7 @@
       {% elif has_active_options %}
         Showing {{ task_items | length }} filtered items
       {% else %}
-        Showing {{ task_items | length }} of {{ total_tasks }} items
+      Showing {{ task_items | length }} of {{ total_tasks }} items
       {% endif %}
     </span>
     <div class="pagination-btns">
@@ -351,17 +355,17 @@
 
     <form method="POST" action="{{ url_for('create_task') }}">
       {% if project %}
-        <input type="hidden" name="project_id" value="{{ project.id }}">
+      <input type="hidden" name="project_id" value="{{ project.id }}">
       {% else %}
-        <div class="project-form-group">
-          <label for="taskProject">Project</label>
-          <select id="taskProject" name="project_id" required>
-            <option value="">Select project</option>
-            {% for project_item in projects %}
-              <option value="{{ project_item.id }}">{{ project_item.name }}</option>
-            {% endfor %}
-          </select>
-        </div>
+      <div class="project-form-group">
+        <label for="taskProject">Project</label>
+        <select id="taskProject" name="project_id" required>
+          <option value="">Select project</option>
+          {% for project_item in projects %}
+          <option value="{{ project_item.id }}">{{ project_item.name }}</option>
+          {% endfor %}
+        </select>
+      </div>
       {% endif %}
 
       <div class="project-form-group">
@@ -411,7 +415,7 @@
           <select id="taskAssignee" name="assignee_id">
             <option value="">Unassigned</option>
             {% for user in users %}
-              <option value="{{ user.id }}">{{ user.full_name }}</option>
+            <option value="{{ user.id }}">{{ user.full_name }}</option>
             {% endfor %}
           </select>
         </div>
@@ -421,7 +425,7 @@
           <select id="taskSprint" name="sprint_id">
             <option value="">No sprint</option>
             {% for sprint in sprints %}
-              <option value="{{ sprint.id }}">{{ sprint.name }}</option>
+            <option value="{{ sprint.id }}">{{ sprint.name }}</option>
             {% endfor %}
           </select>
         </div>
@@ -455,6 +459,102 @@
   </div>
 </div>
 
+{# Edit Task Modals #}
+{% for task in task_items %}
+<div class="project-modal-backdrop" id="editTaskModal{{ task.id }}">
+  <div class="project-modal-card">
+    <div class="project-modal-header">
+      <h2>Edit Task</h2>
+      <button type="button" class="project-modal-close edit-task-close" data-task-id="{{ task.id }}">
+        <i class="bi bi-x-lg"></i>
+      </button>
+    </div>
+
+    <form method="POST" action="{{ url_for('edit_task', task_id=task.id) }}">
+      <input type="hidden" name="project_id" value="{{ task.project_id }}">
+
+      <div class="project-form-group">
+        <label for="editTaskTitle{{ task.id }}">Task Title</label>
+        <input type="text" id="editTaskTitle{{ task.id }}" name="title" value="{{ task.title }}" required />
+      </div>
+
+      <div class="project-form-group">
+        <label for="editTaskDescription{{ task.id }}">Task Description</label>
+        <textarea id="editTaskDescription{{ task.id }}" name="description">{{ task.description or '' }}</textarea>
+      </div>
+
+      <div class="project-form-row">
+        <div class="project-form-group">
+          <label for="editTaskPriority{{ task.id }}">Priority</label>
+          <select id="editTaskPriority{{ task.id }}" name="priority">
+            <option value="low" {% if task.priority=='low' %}selected{% endif %}>Low</option>
+            <option value="medium" {% if task.priority=='medium' %}selected{% endif %}>Medium</option>
+            <option value="high" {% if task.priority=='high' %}selected{% endif %}>High</option>
+          </select>
+        </div>
+
+        <div class="project-form-group">
+          <label for="editTaskStatus{{ task.id }}">Status</label>
+          <select id="editTaskStatus{{ task.id }}" name="status">
+            <option value="backlog" {% if task.status=='backlog' %}selected{% endif %}>Backlog</option>
+            <option value="todo" {% if task.status=='todo' %}selected{% endif %}>Todo</option>
+            <option value="in_progress" {% if task.status=='in_progress' %}selected{% endif %}>In Progress</option>
+            <option value="done" {% if task.status=='done' %}selected{% endif %}>Done</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="project-form-row">
+        <div class="project-form-group">
+          <label for="editTaskAssignee{{ task.id }}">Assignee</label>
+          <select id="editTaskAssignee{{ task.id }}" name="assignee_id">
+            <option value="">Unassigned</option>
+            {% for user in users %}
+            <option value="{{ user.id }}" {% if task.assignee_id==user.id %}selected{% endif %}>
+              {{ user.full_name }}
+            </option>
+            {% endfor %}
+          </select>
+        </div>
+
+        <div class="project-form-group">
+          <label for="editTaskSprint{{ task.id }}">Sprint</label>
+          <select id="editTaskSprint{{ task.id }}" name="sprint_id">
+            <option value="">No sprint</option>
+            {% for sprint in sprints %}
+            <option value="{{ sprint.id }}" {% if task.sprint_id==sprint.id %}selected{% endif %}>
+              {{ sprint.name }}
+            </option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+
+      <div class="project-form-row">
+        <div class="project-form-group">
+          <label for="editTaskStoryPoints{{ task.id }}">Story Points</label>
+          <input type="number" id="editTaskStoryPoints{{ task.id }}" name="story_points" min="0"
+            value="{{ task.story_points }}" />
+        </div>
+
+        <div class="project-form-group">
+          <label for="editTaskDueDate{{ task.id }}">Due Date</label>
+          <input type="date" id="editTaskDueDate{{ task.id }}" name="due_date"
+            value="{{ task.due_date.isoformat() if task.due_date else '' }}" />
+        </div>
+      </div>
+
+      <div class="project-modal-actions">
+        <button type="button" class="project-cancel-btn edit-task-close" data-task-id="{{ task.id }}">
+          Cancel
+        </button>
+        <button type="submit" class="project-submit-btn">Save Changes</button>
+      </div>
+    </form>
+  </div>
+</div>
+{% endfor %}
+
 <script>
   const taskModal = document.getElementById("taskModal");
   const openTaskModal = document.getElementById("openTaskModal");
@@ -485,7 +585,7 @@
     }
   });
 
-    const openViewTaskButtons = document.querySelectorAll(".open-view-task-modal");
+  const openViewTaskButtons = document.querySelectorAll(".open-view-task-modal");
   const closeViewTaskButtons = document.querySelectorAll(".view-task-close");
 
   openViewTaskButtons.forEach(function (button) {
@@ -511,6 +611,37 @@
       }
     });
   });
+
+  const openEditTaskButtons = document.querySelectorAll(".open-edit-task-modal");
+  const closeEditTaskButtons = document.querySelectorAll(".edit-task-close");
+
+  openEditTaskButtons.forEach(function (button) {
+    button.addEventListener("click", function () {
+      const taskId = button.getAttribute("data-task-id");
+      const viewModal = document.getElementById("viewTaskModal" + taskId);
+      const editModal = document.getElementById("editTaskModal" + taskId);
+
+      viewModal.classList.remove("show");
+      editModal.classList.add("show");
+    });
+  });
+
+  closeEditTaskButtons.forEach(function (button) {
+    button.addEventListener("click", function () {
+      const taskId = button.getAttribute("data-task-id");
+      const modal = document.getElementById("editTaskModal" + taskId);
+      modal.classList.remove("show");
+    });
+  });
+
+  document.querySelectorAll("[id^='editTaskModal']").forEach(function (modal) {
+    modal.addEventListener("click", function (event) {
+      if (event.target === modal) {
+        modal.classList.remove("show");
+      }
+    });
+  });
+
 </script>
 
 {% endblock %}


### PR DESCRIPTION
Updated backlog functionality across multiple files.

Changes made:

app/__init__.py
- Updated backlog routes to pass projects, users, and sprints to the template
- Added create_task route to save new tasks into the database
- Added basic task form validation and task creation logic

app/templates/backlog.html
- Added create task modal UI
- Added view task modal UI
- Updated task title click behaviour to open task details
- Added dynamic task details inside the view modal
- Added modal open/close JavaScript functionality

app/static/css/backlog_styles.css
- Added styling for create task modal
- Added styling for view task modal
- Matched modal styling with the existing project modal design
- Fixed create task button styling