### PR TITLE
Add backlog sort and filter controls

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,7 +2,7 @@ import re
 from datetime import date, datetime
 
 import os
-from sqlalchemy import func
+from sqlalchemy import case, func
 from werkzeug.utils import secure_filename
 from flask import Flask, app, flash, g, redirect, render_template, request, session, url_for
 from flask_sqlalchemy import SQLAlchemy
@@ -565,18 +565,67 @@ def create_app():
         search_query=search_query
         )
     
+    def apply_backlog_options(task_query):
+        """
+        Apply backlog filters and sorting from the query string.
+        Kept in one helper so the global and project backlog behave the same way.
+        """
+        status_filter = request.args.get("status", "all").strip()
+        priority_filter = request.args.get("priority", "all").strip()
+        assignee_filter = request.args.get("assignee", "all").strip()
+        sort_by = request.args.get("sort", "newest").strip()
+
+        if status_filter != "all":
+            task_query = task_query.filter(Task.status == status_filter)
+
+        if priority_filter != "all":
+            task_query = task_query.filter(Task.priority == priority_filter)
+
+        if assignee_filter == "assigned":
+            task_query = task_query.filter(Task.assignee_id.isnot(None))
+        elif assignee_filter == "unassigned":
+            task_query = task_query.filter(Task.assignee_id.is_(None))
+
+        priority_order = case(
+            (Task.priority == "high", 1),
+            (Task.priority == "medium", 2),
+            (Task.priority == "low", 3),
+            else_=4
+        )
+
+        if sort_by == "due_date":
+            task_query = task_query.order_by(Task.due_date.is_(None), Task.due_date.asc())
+        elif sort_by == "priority":
+            task_query = task_query.order_by(priority_order.asc(), Task.created_at.desc())
+        elif sort_by == "title":
+            task_query = task_query.order_by(func.lower(Task.title).asc())
+        else:
+            task_query = task_query.order_by(Task.created_at.desc())
+
+        backlog_options = {
+            "status": status_filter,
+            "priority": priority_filter,
+            "assignee": assignee_filter,
+            "sort": sort_by
+        }
+
+        return task_query, backlog_options
+
     @app.route("/projects/<int:project_id>/backlog")
     def project_backlog(project_id):
         if g.user is None:
             return redirect(url_for("auth", mode="login"))
 
         project = Project.query.get_or_404(project_id)
-        tasks = Task.query.filter_by(project_id=project.id).all()
+        task_query = Task.query.filter_by(project_id=project.id)
+        task_query, backlog_options = apply_backlog_options(task_query)
+        tasks = task_query.all()
 
         return render_template(
             "backlog.html",
             project=project,
-            tasks=tasks
+            tasks=tasks,
+            backlog_options=backlog_options
         )
     
     @app.route("/projects/<int:project_id>/assign-users", methods=["POST"])
@@ -644,12 +693,14 @@ def create_app():
         if g.user is None:
             return redirect(url_for("auth", mode="login"))
 
-        tasks = Task.query.order_by(Task.created_at.desc()).all()
+        task_query, backlog_options = apply_backlog_options(Task.query)
+        tasks = task_query.all()
 
         return render_template(
           "backlog.html",
           project=None,
-          tasks=tasks
+          tasks=tasks,
+          backlog_options=backlog_options
         )
     
     # Route for user profile page

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -599,6 +599,10 @@ def create_app():
             task_query = task_query.filter(Task.assignee_id.isnot(None))
         elif assignee_filter == "unassigned":
             task_query = task_query.filter(Task.assignee_id.is_(None))
+        elif assignee_filter.startswith("user_"):
+            user_id = assignee_filter.replace("user_", "", 1)
+            if user_id.isdigit():
+                task_query = task_query.filter(Task.assignee_id == int(user_id))
 
         priority_order = case(
             (Task.priority == "high", 1),
@@ -635,6 +639,15 @@ def create_app():
         base_task_query = Task.query.filter_by(project_id=project.id)
         total_task_count = base_task_query.count()
         total_unassigned_count = base_task_query.filter(Task.assignee_id.is_(None)).count()
+        # Only show users who already have tasks in this backlog.
+        assignee_options = (
+            User.query
+            .join(Task, Task.assignee_id == User.id)
+            .filter(Task.project_id == project.id)
+            .distinct()
+            .order_by(User.full_name.asc())
+            .all()
+        )
         task_query = apply_backlog_search(base_task_query, search_query)
         task_query, backlog_options = apply_backlog_options(task_query)
         tasks = task_query.all()
@@ -646,7 +659,8 @@ def create_app():
             search_query=search_query,
             total_task_count=total_task_count,
             total_unassigned_count=total_unassigned_count,
-            backlog_options=backlog_options
+            backlog_options=backlog_options,
+            assignee_options=assignee_options
         )
     
     @app.route("/projects/<int:project_id>/assign-users", methods=["POST"])
@@ -718,6 +732,14 @@ def create_app():
         base_task_query = Task.query
         total_task_count = base_task_query.count()
         total_unassigned_count = base_task_query.filter(Task.assignee_id.is_(None)).count()
+        # Only show users who already have tasks in the backlog.
+        assignee_options = (
+            User.query
+            .join(Task, Task.assignee_id == User.id)
+            .distinct()
+            .order_by(User.full_name.asc())
+            .all()
+        )
         task_query = apply_backlog_search(base_task_query, search_query)
         task_query, backlog_options = apply_backlog_options(task_query)
         tasks = task_query.all()
@@ -729,7 +751,8 @@ def create_app():
           search_query=search_query,
           total_task_count=total_task_count,
           total_unassigned_count=total_unassigned_count,
-          backlog_options=backlog_options
+          backlog_options=backlog_options,
+          assignee_options=assignee_options
         )
     
     # Route for user profile page

--- a/app/static/css/backlog_styles.css
+++ b/app/static/css/backlog_styles.css
@@ -208,6 +208,22 @@
   outline: none;
 }
 
+.backlog-reset-link {
+  padding: 9px 14px;
+  border: 1px solid #d7dee8;
+  border-radius: 10px;
+  color: #475569;
+  background-color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.backlog-reset-link:hover {
+  border-color: #1D9E75;
+  color: #1D9E75;
+}
+
 .backlog-member-stack {
   display: flex;
   align-items: center;

--- a/app/static/css/backlog_styles.css
+++ b/app/static/css/backlog_styles.css
@@ -170,6 +170,44 @@
   color: #0f4c5c;
 }
 
+.backlog-filter-form {
+  display: flex;
+  align-items: end;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.backlog-filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+}
+
+.backlog-filter-field span {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #64748b;
+  text-transform: uppercase;
+}
+
+.backlog-filter-field select {
+  min-width: 128px;
+  padding: 8px 32px 8px 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background-color: #ffffff;
+  color: #0f172a;
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.backlog-filter-field select:focus {
+  border-color: #1D9E75;
+  box-shadow: 0 0 0 3px rgba(29, 158, 117, 0.12);
+  outline: none;
+}
+
 .backlog-member-stack {
   display: flex;
   align-items: center;

--- a/app/templates/backlog.html
+++ b/app/templates/backlog.html
@@ -108,6 +108,11 @@
           <option value="all" {% if selected_assignee == 'all' %}selected{% endif %}>All</option>
           <option value="assigned" {% if selected_assignee == 'assigned' %}selected{% endif %}>Assigned</option>
           <option value="unassigned" {% if selected_assignee == 'unassigned' %}selected{% endif %}>Unassigned</option>
+          {% for assignee in assignee_options|default([]) %}
+          <option value="user_{{ assignee.id }}" {% if selected_assignee == 'user_' ~ assignee.id|string %}selected{% endif %}>
+            {{ assignee.full_name }}
+          </option>
+          {% endfor %}
         </select>
       </label>
 

--- a/app/templates/backlog.html
+++ b/app/templates/backlog.html
@@ -20,6 +20,8 @@
 {% set selected_priority = backlog_options.get('priority', 'all') %}
 {% set selected_assignee = backlog_options.get('assignee', 'all') %}
 {% set selected_sort = backlog_options.get('sort', 'newest') %}
+{% set has_active_options = selected_status != 'all' or selected_priority != 'all' or selected_assignee != 'all' or selected_sort != 'newest' %}
+{% set backlog_url = url_for('project_backlog', project_id=project.id) if project else url_for('backlog') %}
 {% set total_tasks = task_items|length %}
 {% set unassigned_count = task_items|selectattr("assignee", "none")|list|length %}
 {% set project_name = project.name if project else 'No Project Selected' %}
@@ -111,6 +113,12 @@
           <option value="title" {% if selected_sort == 'title' %}selected{% endif %}>Title</option>
         </select>
       </label>
+
+      {% if has_active_options %}
+      <a href="{{ backlog_url }}" class="backlog-reset-link">
+        <i class="bi bi-x-circle me-1"></i> Reset
+      </a>
+      {% endif %}
     </form>
   </div>
 </section>
@@ -215,7 +223,11 @@
   {# Table footer: count + pagination #}
   <div class="backlog-table-footer">
     <span class="showing-label">
-      Showing {{ task_items | length }} of {{ total_tasks }} items
+      {% if has_active_options %}
+        Showing {{ task_items | length }} filtered items
+      {% else %}
+        Showing {{ task_items | length }} of {{ total_tasks }} items
+      {% endif %}
     </span>
     <div class="pagination-btns">
       <a href="#" class="page-btn">Previous</a>

--- a/app/templates/backlog.html
+++ b/app/templates/backlog.html
@@ -15,6 +15,11 @@
 
 {# task data from backend route #}
 {% set task_items = tasks %}
+{% set backlog_options = backlog_options|default({}) %}
+{% set selected_status = backlog_options.get('status', 'all') %}
+{% set selected_priority = backlog_options.get('priority', 'all') %}
+{% set selected_assignee = backlog_options.get('assignee', 'all') %}
+{% set selected_sort = backlog_options.get('sort', 'newest') %}
 {% set total_tasks = task_items|length %}
 {% set unassigned_count = task_items|selectattr("assignee", "none")|list|length %}
 {% set project_name = project.name if project else 'No Project Selected' %}
@@ -66,12 +71,47 @@
       </a>
     </div>
 
-    <a href="#" class="toolbar-action-btn">
-      <i class="bi bi-funnel me-1"></i> Filters
-    </a>
-    <a href="#" class="toolbar-action-btn">
-      <i class="bi bi-sort-down me-1"></i> Sort
-    </a>
+    <form method="GET" class="backlog-filter-form">
+      <label class="backlog-filter-field">
+        <span>Status</span>
+        <select name="status" onchange="this.form.submit()">
+          <option value="all" {% if selected_status == 'all' %}selected{% endif %}>All</option>
+          <option value="todo" {% if selected_status == 'todo' %}selected{% endif %}>To Do</option>
+          <option value="in_progress" {% if selected_status == 'in_progress' %}selected{% endif %}>In Progress</option>
+          <option value="blocker" {% if selected_status == 'blocker' %}selected{% endif %}>Blocker</option>
+          <option value="done" {% if selected_status == 'done' %}selected{% endif %}>Done</option>
+        </select>
+      </label>
+
+      <label class="backlog-filter-field">
+        <span>Priority</span>
+        <select name="priority" onchange="this.form.submit()">
+          <option value="all" {% if selected_priority == 'all' %}selected{% endif %}>All</option>
+          <option value="high" {% if selected_priority == 'high' %}selected{% endif %}>High</option>
+          <option value="medium" {% if selected_priority == 'medium' %}selected{% endif %}>Medium</option>
+          <option value="low" {% if selected_priority == 'low' %}selected{% endif %}>Low</option>
+        </select>
+      </label>
+
+      <label class="backlog-filter-field">
+        <span>Assignee</span>
+        <select name="assignee" onchange="this.form.submit()">
+          <option value="all" {% if selected_assignee == 'all' %}selected{% endif %}>All</option>
+          <option value="assigned" {% if selected_assignee == 'assigned' %}selected{% endif %}>Assigned</option>
+          <option value="unassigned" {% if selected_assignee == 'unassigned' %}selected{% endif %}>Unassigned</option>
+        </select>
+      </label>
+
+      <label class="backlog-filter-field">
+        <span>Sort</span>
+        <select name="sort" onchange="this.form.submit()">
+          <option value="newest" {% if selected_sort == 'newest' %}selected{% endif %}>Newest</option>
+          <option value="due_date" {% if selected_sort == 'due_date' %}selected{% endif %}>Due Date</option>
+          <option value="priority" {% if selected_sort == 'priority' %}selected{% endif %}>Priority</option>
+          <option value="title" {% if selected_sort == 'title' %}selected{% endif %}>Title</option>
+        </select>
+      </label>
+    </form>
   </div>
 </section>
 

--- a/app/templates/components/sidebar.html
+++ b/app/templates/components/sidebar.html
@@ -46,12 +46,9 @@
     </div>
 
     <div class="sidebar-bottom">
-      <a href="#" class="nav-link">
-        <i class="bi bi-question-circle me-2"></i> Help
-      </a>
       <a href="/settings" class="nav-link {% if request.endpoint == 'settings' %}active{% endif %}">
         <i class="bi bi-gear me-2"></i> Settings
-    </a>
+      </a>
     </div>
   </div>
 </aside>


### PR DESCRIPTION
**Description**

This PR adds sorting and filtering to the backlog page.

**What was added**

- filter tasks by status, priority, and assignee
- show assignee names in the assignee filter
- sort tasks by newest, due date, priority, or title
- keep search working together with the new filters
- add reset state for clearing selected filters
- removed the unused Help link from the sidebar

**Key files changed**

app/__init__.py  
app/templates/backlog.html  
app/static/css/backlog_styles.css

Closes #38