### PR TITLE
Add dashboard task modal and polish sprint actions

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -776,55 +776,110 @@ def create_app():
             assignee_options=assignee_options
         )
 
-    @app.route("/tasks/create", methods=["POST"])
-    def create_task():
-        if g.user is None:
-            return redirect(url_for("auth", mode="login"))
-
+    def get_task_form_data():
+        """
+        Amit: shared task form validation for create and edit.
+        The main check here is that the selected sprint belongs to the selected project.
+        """
+        errors = []
         title = request.form.get("title", "").strip()
         description = request.form.get("description", "").strip()
-        project_id = request.form.get("project_id")
-        sprint_id = request.form.get("sprint_id")
-        assignee_id = request.form.get("assignee_id")
+        project_id = request.form.get("project_id", "")
+        sprint_id = request.form.get("sprint_id", "")
+        assignee_id = request.form.get("assignee_id", "")
         priority = request.form.get("priority", "medium")
         status = request.form.get("status", "backlog")
         story_points_raw = request.form.get("story_points", "0")
         due_date_raw = request.form.get("due_date", "")
 
-        if not title or not project_id:
-            flash("Task title and project are required.", "error")
-            return redirect(request.referrer or url_for("backlog"))
+        project = db.session.get(Project, int(project_id)) if project_id.isdigit() else None
+        if not title:
+            errors.append("Task title is required.")
+        if not project:
+            errors.append("Please select a valid project.")
+
+        sprint = None
+        if sprint_id:
+            sprint = db.session.get(Sprint, int(sprint_id)) if sprint_id.isdigit() else None
+            if not sprint:
+                errors.append("Please select a valid sprint.")
+            elif project and sprint.project_id != project.id:
+                errors.append("Sprint must belong to the selected project.")
+
+        assignee = None
+        if assignee_id:
+            assignee = db.session.get(User, int(assignee_id)) if assignee_id.isdigit() else None
+            if not assignee:
+                errors.append("Please select a valid assignee.")
 
         try:
-            story_points = int(story_points_raw)
+            story_points = int(story_points_raw or 0)
         except ValueError:
             story_points = 0
+            errors.append("Story points must be a number.")
+
+        if story_points < 0:
+            errors.append("Story points cannot be negative.")
 
         due_date = None
         if due_date_raw:
             try:
                 due_date = date.fromisoformat(due_date_raw)
             except ValueError:
-                due_date = None
+                errors.append("Please enter a valid due date.")
+
+        if priority not in {"low", "medium", "high"}:
+            priority = "medium"
+
+        if status not in {"backlog", "todo", "in_progress", "blocker", "done"}:
+            status = "backlog"
+
+        task_data = {
+            "title": title,
+            "description": description,
+            "project": project,
+            "sprint": sprint,
+            "assignee": assignee,
+            "priority": priority,
+            "status": status,
+            "story_points": story_points,
+            "due_date": due_date,
+        }
+
+        return task_data, errors
+
+    def task_form_redirect():
+        return redirect(request.referrer or url_for("backlog"))
+
+    @app.route("/tasks/create", methods=["POST"])
+    def create_task():
+        if g.user is None:
+            return redirect(url_for("auth", mode="login"))
+
+        task_data, errors = get_task_form_data()
+        if errors:
+            for error in errors:
+                flash(error, "error")
+            return task_form_redirect()
 
         task = Task(
-            title=title,
-            description=description,
-            project_id=int(project_id),
-            sprint_id=int(sprint_id) if sprint_id else None,
-            assignee_id=int(assignee_id) if assignee_id else None,
+            title=task_data["title"],
+            description=task_data["description"],
+            project_id=task_data["project"].id,
+            sprint_id=task_data["sprint"].id if task_data["sprint"] else None,
+            assignee_id=task_data["assignee"].id if task_data["assignee"] else None,
             created_by=g.user.id,
-            priority=priority,
-            status=status,
-            story_points=story_points,
-            due_date=due_date,
+            priority=task_data["priority"],
+            status=task_data["status"],
+            story_points=task_data["story_points"],
+            due_date=task_data["due_date"],
         )
 
         db.session.add(task)
         db.session.commit()
 
         flash("Task created successfully.", "success")
-        return redirect(request.referrer or url_for("backlog"))
+        return task_form_redirect()
 
     @app.route("/tasks/<int:task_id>/edit", methods=["POST"])
     def edit_task(task_id):
@@ -832,47 +887,26 @@ def create_app():
             return redirect(url_for("auth", mode="login"))
 
         task = Task.query.get_or_404(task_id)
+        task_data, errors = get_task_form_data()
+        if errors:
+            for error in errors:
+                flash(error, "error")
+            return task_form_redirect()
 
-        title = request.form.get("title", "").strip()
-        description = request.form.get("description", "").strip()
-        project_id = request.form.get("project_id")
-        sprint_id = request.form.get("sprint_id")
-        assignee_id = request.form.get("assignee_id")
-        priority = request.form.get("priority", "medium")
-        status = request.form.get("status", "backlog")
-        story_points_raw = request.form.get("story_points", "0")
-        due_date_raw = request.form.get("due_date", "")
-
-        if not title or not project_id:
-            flash("Task title and project are required.", "error")
-            return redirect(request.referrer or url_for("backlog"))
-
-        try:
-            story_points = int(story_points_raw)
-        except ValueError:
-            story_points = 0
-
-        due_date = None
-        if due_date_raw:
-            try:
-                due_date = date.fromisoformat(due_date_raw)
-            except ValueError:
-                due_date = None
-
-        task.title = title
-        task.description = description
-        task.project_id = int(project_id)
-        task.sprint_id = int(sprint_id) if sprint_id else None
-        task.assignee_id = int(assignee_id) if assignee_id else None
-        task.priority = priority
-        task.status = status
-        task.story_points = story_points
-        task.due_date = due_date
+        task.title = task_data["title"]
+        task.description = task_data["description"]
+        task.project_id = task_data["project"].id
+        task.sprint_id = task_data["sprint"].id if task_data["sprint"] else None
+        task.assignee_id = task_data["assignee"].id if task_data["assignee"] else None
+        task.priority = task_data["priority"]
+        task.status = task_data["status"]
+        task.story_points = task_data["story_points"]
+        task.due_date = task_data["due_date"]
 
         db.session.commit()
 
         flash("Task updated successfully.", "success")
-        return redirect(request.referrer or url_for("backlog"))
+        return task_form_redirect()
     
     # Route for user profile page
     @app.route("/profile", methods=["GET", "POST"])

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -142,6 +142,9 @@ def create_app():
         # Show the user's assigned tasks in due-date order on the dashboard.
         tasks = sorted(tasks, key=lambda task: (task.due_date is None, task.due_date or date.max))
         assigned_task_count = len(tasks)
+        task_projects = Project.query.filter_by(status="active").order_by(Project.name.asc()).all()
+        task_users = User.query.filter_by(is_active=True).order_by(User.full_name.asc()).all()
+        task_sprints = Sprint.query.order_by(Sprint.start_date.asc()).all()
 
         # Default values keep the dashboard working even when no sprint exists yet.
         sprint_summary = {
@@ -203,6 +206,9 @@ def create_app():
             sprint_summary=sprint_summary,
             assigned_task_count=assigned_task_count,
             tasks=tasks,
+            task_projects=task_projects,
+            task_users=task_users,
+            task_sprints=task_sprints,
         )
 
     # Route for sprints page

--- a/app/models.py
+++ b/app/models.py
@@ -236,7 +236,7 @@ class Task(db.Model):
     task_code = db.Column(db.String(30), unique=True, nullable=True)
 
     priority = db.Column(db.String(20), default="medium")   # low, medium, high
-    status = db.Column(db.String(30), default="backlog")    # backlog, todo, in_progress, done
+    status = db.Column(db.String(30), default="backlog")    # backlog, todo, in_progress, blocker, done
     story_points = db.Column(db.Integer, default=0)
 
     due_date = db.Column(db.Date, nullable=True)

--- a/app/static/css/dashboard_styles.css
+++ b/app/static/css/dashboard_styles.css
@@ -314,6 +314,29 @@ body {
   color: #ffffff;
 }
 
+.dashboard-task-modal {
+  border: none;
+  border-radius: 16px;
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.18);
+}
+
+.dashboard-task-modal .modal-header,
+.dashboard-task-modal .modal-footer {
+  border-color: #eef2f7;
+}
+
+.dashboard-task-modal .form-label {
+  color: #475569;
+  font-size: 0.82rem;
+}
+
+.dashboard-task-modal .form-control,
+.dashboard-task-modal .form-select {
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  min-height: 44px;
+}
+
 .table-card {
   overflow: hidden;
 }

--- a/app/static/css/index.css
+++ b/app/static/css/index.css
@@ -74,6 +74,10 @@ body {
 
 .landing-login-link {
   color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  margin-right: 14px;
+  padding: 8px 2px;
   font-size: 14px;
   font-weight: 600;
   text-decoration: none;

--- a/app/static/css/index.css
+++ b/app/static/css/index.css
@@ -72,6 +72,17 @@ body {
   transform: translateY(-1px);
 }
 
+.landing-login-link {
+  color: var(--text-muted);
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.landing-login-link:hover {
+  color: var(--green-primary);
+}
+
 /* ── HERO ── */
 .hero-section {
   background: linear-gradient(160deg, #eaf7f2 0%, var(--bg-page) 60%);

--- a/app/templates/backlog.html
+++ b/app/templates/backlog.html
@@ -404,6 +404,7 @@
             <option value="backlog" selected>Backlog</option>
             <option value="todo">Todo</option>
             <option value="in_progress">In Progress</option>
+            <option value="blocker">Blocker</option>
             <option value="done">Done</option>
           </select>
         </div>
@@ -499,6 +500,7 @@
             <option value="backlog" {% if task.status=='backlog' %}selected{% endif %}>Backlog</option>
             <option value="todo" {% if task.status=='todo' %}selected{% endif %}>Todo</option>
             <option value="in_progress" {% if task.status=='in_progress' %}selected{% endif %}>In Progress</option>
+            <option value="blocker" {% if task.status=='blocker' %}selected{% endif %}>Blocker</option>
             <option value="done" {% if task.status=='done' %}selected{% endif %}>Done</option>
           </select>
         </div>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -71,7 +71,14 @@ block content %} {% set topbar_title = 'Dashboard' %} {% set topbar_search_class
         My Assigned Tasks
         <span class="text-muted fs-6">({{ assigned_task_count }})</span>
       </h2>
-      <button class="btn new-task-btn">+ New Task</button>
+      <button
+        class="btn new-task-btn"
+        type="button"
+        data-bs-toggle="modal"
+        data-bs-target="#dashboardTaskModal"
+      >
+        + New Task
+      </button>
     </div>
 
     <div class="table-card">
@@ -161,4 +168,151 @@ block content %} {% set topbar_title = 'Dashboard' %} {% set topbar_search_class
     </div>
   </div>
 </section>
+
+{# Amit: quick task modal from the dashboard, using the same backend as backlog. #}
+<div class="modal fade" id="dashboardTaskModal" tabindex="-1" aria-labelledby="dashboardTaskModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered">
+    <div class="modal-content dashboard-task-modal">
+      <form method="POST" action="{{ url_for('create_task') }}">
+        <div class="modal-header">
+          <h5 class="modal-title fw-bold" id="dashboardTaskModalLabel">Create New Task</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+
+        <div class="modal-body">
+          <div class="row g-3">
+            <div class="col-md-6">
+              <label class="form-label fw-semibold" for="dashboardTaskProject">Project</label>
+              <select class="form-select" id="dashboardTaskProject" name="project_id" required>
+                <option value="">Select project</option>
+                {% for project in task_projects %}
+                <option value="{{ project.id }}">{{ project.name }}</option>
+                {% endfor %}
+              </select>
+            </div>
+
+            <div class="col-md-6">
+              <label class="form-label fw-semibold" for="dashboardTaskTitle">Task Title</label>
+              <input
+                type="text"
+                class="form-control"
+                id="dashboardTaskTitle"
+                name="title"
+                placeholder="e.g. Update sprint notes"
+                required
+              />
+            </div>
+
+            <div class="col-12">
+              <label class="form-label fw-semibold" for="dashboardTaskDescription">Description</label>
+              <textarea
+                class="form-control"
+                id="dashboardTaskDescription"
+                name="description"
+                rows="3"
+                placeholder="Add a short task description"
+              ></textarea>
+            </div>
+
+            <div class="col-md-4">
+              <label class="form-label fw-semibold" for="dashboardTaskPriority">Priority</label>
+              <select class="form-select" id="dashboardTaskPriority" name="priority">
+                <option value="low">Low</option>
+                <option value="medium" selected>Medium</option>
+                <option value="high">High</option>
+              </select>
+            </div>
+
+            <div class="col-md-4">
+              <label class="form-label fw-semibold" for="dashboardTaskStatus">Status</label>
+              <select class="form-select" id="dashboardTaskStatus" name="status">
+                <option value="backlog" selected>Backlog</option>
+                <option value="todo">To Do</option>
+                <option value="in_progress">In Progress</option>
+                <option value="blocker">Blocker</option>
+                <option value="done">Done</option>
+              </select>
+            </div>
+
+            <div class="col-md-4">
+              <label class="form-label fw-semibold" for="dashboardTaskStoryPoints">Story Points</label>
+              <input
+                type="number"
+                class="form-control"
+                id="dashboardTaskStoryPoints"
+                name="story_points"
+                min="0"
+                value="0"
+              />
+            </div>
+
+            <div class="col-md-6">
+              <label class="form-label fw-semibold" for="dashboardTaskAssignee">Assignee</label>
+              <select class="form-select" id="dashboardTaskAssignee" name="assignee_id">
+                <option value="">Unassigned</option>
+                {% for user_item in task_users %}
+                <option value="{{ user_item.id }}">{{ user_item.full_name }}</option>
+                {% endfor %}
+              </select>
+            </div>
+
+            <div class="col-md-6">
+              <label class="form-label fw-semibold" for="dashboardTaskSprint">Sprint</label>
+              <select class="form-select" id="dashboardTaskSprint" name="sprint_id">
+                <option value="">No sprint</option>
+                {% for sprint in task_sprints %}
+                <option value="{{ sprint.id }}" data-project-id="{{ sprint.project_id }}">
+                  {{ sprint.name }} - {{ sprint.project.name }}
+                </option>
+                {% endfor %}
+              </select>
+            </div>
+
+            <div class="col-md-6">
+              <label class="form-label fw-semibold" for="dashboardTaskDueDate">Due Date</label>
+              <input type="date" class="form-control" id="dashboardTaskDueDate" name="due_date" />
+            </div>
+          </div>
+        </div>
+
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn new-task-btn">Save Task</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<script>
+  // Amit: only show sprints that belong to the selected project.
+  const dashboardProjectSelect = document.getElementById("dashboardTaskProject");
+  const dashboardSprintSelect = document.getElementById("dashboardTaskSprint");
+
+  if (dashboardProjectSelect && dashboardSprintSelect) {
+    function filterDashboardSprints() {
+      const selectedProjectId = dashboardProjectSelect.value;
+
+      Array.from(dashboardSprintSelect.options).forEach(function (option) {
+        if (!option.value) {
+          option.hidden = false;
+          option.disabled = false;
+          return;
+        }
+
+        const matchesProject = option.dataset.projectId === selectedProjectId;
+        option.hidden = !selectedProjectId || !matchesProject;
+        option.disabled = !selectedProjectId || !matchesProject;
+      });
+
+      const selectedOption = dashboardSprintSelect.selectedOptions[0];
+      if (selectedOption && selectedOption.disabled) {
+        dashboardSprintSelect.value = "";
+      }
+    }
+
+    dashboardProjectSelect.addEventListener("change", filterDashboardSprints);
+    filterDashboardSprints();
+  }
+</script>
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -21,6 +21,10 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/index.css') }}" />
 </head>
 <body>
+  {# Amit: Get Started is for new users, while Log In is separate for existing users. #}
+  {% set get_started_url = url_for('auth', mode='register') %}
+  {% set login_url = url_for('auth', mode='login') %}
+  {% set dashboard_url = url_for('dashboard') %}
 
   <!-- NAVBAR -->
   <nav class="navbar navbar-expand-md sticky-top py-0">
@@ -38,8 +42,12 @@
           <li class="nav-item"><a class="nav-link" href="#features">Features</a></li>
           <li class="nav-item"><a class="nav-link" href="#how-it-works">How it works</a></li>
         </ul>
-        <!-- Navigate to auth route using Flask url_for -->
-        <a href="{{ url_for('auth') }}" class="btn-get-started">Get Started</a>
+        {% if g.user %}
+        <a href="{{ dashboard_url }}" class="btn-get-started">Open Dashboard</a>
+        {% else %}
+        <a href="{{ login_url }}" class="landing-login-link">Log In</a>
+        <a href="{{ get_started_url }}" class="btn-get-started">Get Started</a>
+        {% endif %}
       </div>
     </div>
   </nav>
@@ -61,8 +69,12 @@
             and stay aligned throughout the sprint.
           </p>
           <div class="d-flex flex-wrap gap-3 mb-4">
-            <!-- Flask route for authentication page -->
-            <a href="{{ url_for('auth') }}" class="btn-primary-green">Get started — it's free</a>
+            <a href="{{ get_started_url if not g.user else dashboard_url }}" class="btn-primary-green">
+              {{ 'Open Dashboard' if g.user else "Get started — it's free" }}
+            </a>
+            {% if not g.user %}
+            <a href="{{ login_url }}" class="btn-outline-hero">Log in</a>
+            {% endif %}
           </div>
           <div class="d-flex flex-wrap gap-4">
             <span class="hero-check"><i class="fas fa-check-circle"></i> Sprint planning</span>
@@ -83,7 +95,9 @@
                 <span>Features</span>
                 <span>How it works</span>
               </div>
-              <a href="{{ url_for('auth') }}" class="mockup-top-btn">Get Started</a>
+              <a href="{{ get_started_url if not g.user else dashboard_url }}" class="mockup-top-btn">
+                {{ 'Dashboard' if g.user else 'Get Started' }}
+              </a>
             </div>
             <div class="mockup-content">
               <div class="mockup-sidebar">
@@ -246,7 +260,9 @@
     <div class="container">
       <h2 class="mb-3">Ready to run better sprints?</h2>
       <p class="mb-4">Join your team on Agile PM and start delivering value today.</p>
-      <a href="{{ url_for('auth') }}" class="btn-white">Get started — it's free</a>
+      <a href="{{ get_started_url if not g.user else dashboard_url }}" class="btn-white">
+        {{ 'Open Dashboard' if g.user else "Get started — it's free" }}
+      </a>
     </div>
   </section>
 

--- a/app/templates/sprints.html
+++ b/app/templates/sprints.html
@@ -15,9 +15,6 @@
 {% set topbar_title = 'Sprints' %}
 {% set topbar_search_placeholder = 'Search tasks or sprints...' %}
 {% set topbar_search_class = 'd-none' %}
-{% set topbar_action_label = '+ New Sprint' %}
-{% set topbar_action_class = 'primary-action-btn' %}
-{% set topbar_action_modal_id = 'newSprintModal' %}
 {% include "components/topbar.html" %}
 
 <section class="welcome-section sprint-page-heading">
@@ -46,7 +43,7 @@
     </div>
     <div class="heading-actions">
       <button
-        class="btn outline-action-btn"
+        class="btn primary-action-btn"
         type="button"
         data-bs-toggle="modal"
         data-bs-target="#newSprintModal"
@@ -55,7 +52,7 @@
       </button>
       {% if current_sprint.id %}
       <form method="POST" action="{{ url_for('complete_sprint', sprint_id=current_sprint.id) }}">
-        <button type="submit" class="btn primary-action-btn">Complete Sprint</button>
+        <button type="submit" class="btn outline-action-btn">Complete Sprint</button>
       </form>
       {% endif %}
     </div>


### PR DESCRIPTION
**Description**

This PR updates a few remaining dashboard, sprint, and task workflow items.

**What was added**

removed the duplicate New Sprint button on the sprints page
kept the main New Sprint button green and changed Complete Sprint to outline style
made Get Started on the landing page clearly point to registration
added a separate Log In link for existing users
added a new task modal to the dashboard New Task button
added validation so a task cannot be assigned to a sprint from another project
added Blocker as a task status option in task forms

**Key files changed**

app/__init__.py
app/templates/dashboard.html
app/templates/index.html
app/templates/sprints.html
app/templates/backlog.html
app/static/css/dashboard_styles.css
app/static/css/index.css
app/models.py