### PR TITLE
Add CSRF protection to all POST forms

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,12 +7,14 @@ from werkzeug.utils import secure_filename
 from flask import Flask, app, flash, g, redirect, render_template, request, session, url_for
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
+from flask_wtf.csrf import CSRFProtect
 from werkzeug.security import check_password_hash, generate_password_hash
 from config import Config
 
 # Create extension objects globally
 db = SQLAlchemy()
 migrate = Migrate()
+csrf = CSRFProtect()
 
 
 def create_app(test_config=None):
@@ -26,10 +28,12 @@ def create_app(test_config=None):
     app.config.from_object(Config)
     if test_config is not None:
         app.config.update(test_config)
+    app.config.setdefault("WTF_CSRF_CHECK_DEFAULT", False)
 
     # Initialize extensions
     db.init_app(app)
     migrate.init_app(app, db)
+    csrf.init_app(app)
 
     # Import models so SQLAlchemy and migrations can detect them
     from app import models

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -28,7 +28,6 @@ def create_app(test_config=None):
     app.config.from_object(Config)
     if test_config is not None:
         app.config.update(test_config)
-    app.config.setdefault("WTF_CSRF_CHECK_DEFAULT", False)
 
     # Initialize extensions
     db.init_app(app)

--- a/app/templates/auth.html
+++ b/app/templates/auth.html
@@ -113,6 +113,7 @@
                             data-auth-form="register"
                         >
                         <input type="hidden" name="form_type" value="register">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
                         <label class="form-label">FULL NAME</label>
                         <input
@@ -178,6 +179,7 @@
                             data-auth-form="login"
                         >
                         <input type="hidden" name="form_type" value="login">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
                         <label class="form-label">EMAIL</label>
                         <input

--- a/app/templates/backlog.html
+++ b/app/templates/backlog.html
@@ -356,6 +356,7 @@
     </div>
 
     <form method="POST" action="{{ url_for('create_task') }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       {% if project %}
       <input type="hidden" name="project_id" value="{{ project.id }}">
       {% else %}
@@ -474,6 +475,7 @@
     </div>
 
     <form method="POST" action="{{ url_for('edit_task', task_id=task.id) }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <input type="hidden" name="project_id" value="{{ task.project_id }}">
 
       <div class="project-form-group">

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -179,6 +179,7 @@ block content %} {% set topbar_title = 'Dashboard' %} {% set topbar_search_class
   <div class="modal-dialog modal-lg modal-dialog-centered">
     <div class="modal-content dashboard-task-modal">
       <form method="POST" action="{{ url_for('create_task') }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="modal-header">
           <h5 class="modal-title fw-bold" id="dashboardTaskModalLabel">Create New Task</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -90,6 +90,7 @@
   <div class="modal-dialog modal-dialog-centered" style="max-width:480px;">
     <div class="modal-content" style="border-radius:16px;border:none;box-shadow:0 8px 32px rgba(0,0,0,0.15);">
       <form method="POST" action="{{ url_for('profile') }}" enctype="multipart/form-data">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="modal-header" style="border-bottom:none;padding:16px 20px 0;">
           <h5 class="modal-title" style="font-size:1rem;font-weight:600;">Edit Profile</h5>
           <button type="button" class="btn-close" style="font-size:0.75rem;" data-bs-dismiss="modal"></button>

--- a/app/templates/project.html
+++ b/app/templates/project.html
@@ -117,6 +117,7 @@ block extra_css %}
     </div>
 
     <form method="POST" action="{{ url_for('create_project') }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="project-form-row">
         <div class="project-form-group project-name-field">
           <label for="projectName">Project Name</label>

--- a/app/templates/project_detail.html
+++ b/app/templates/project_detail.html
@@ -35,6 +35,7 @@ topbar_search_placeholder = 'Search projects...' %} {% include
       </button>
 
       <form method="POST" action="">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <button type="button" class="detail-btn delete" id="openDeleteProjectModal">
             Delete<br />Project
         </button>
@@ -160,6 +161,7 @@ topbar_search_placeholder = 'Search projects...' %} {% include
       method="POST"
       action="{{ url_for('assign_project_users', project_id=project.id) }}"
     >
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="assign-users-list">
         {% for user in users %}
         <label class="assign-user-row">
@@ -220,6 +222,7 @@ topbar_search_placeholder = 'Search projects...' %} {% include
       method="POST"
       action="{{ url_for('edit_project', project_id=project.id) }}"
     >
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="project-form-group">
         <label>Name</label>
         <input type="text" name="name" value="{{ project.name }}" required />
@@ -304,6 +307,7 @@ topbar_search_placeholder = 'Search projects...' %} {% include
       </button>
 
       <form method="POST" action="{{ url_for('delete_project', project_id=project.id) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <button type="submit" class="project-delete-submit-btn">
           Delete Project
         </button>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -37,6 +37,7 @@
 
         <form method="POST" action="{{ url_for('settings') }}"
               enctype="multipart/form-data" id="settings-form">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
             <!-- ── Section 1: Account ── -->
             <div class="settings-card">

--- a/app/templates/sprints.html
+++ b/app/templates/sprints.html
@@ -52,6 +52,7 @@
       </button>
       {% if current_sprint.id %}
       <form method="POST" action="{{ url_for('complete_sprint', sprint_id=current_sprint.id) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <button type="submit" class="btn outline-action-btn">Complete Sprint</button>
       </form>
       {% endif %}
@@ -138,6 +139,7 @@
     </div>
 
     <form method="POST" action="{{ url_for('submit_sprint_checkin', sprint_id=current_sprint.id) }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="sprint-checkin-grid">
         <div>
           <label class="form-label fw-semibold" for="confidence_level">Confidence</label>
@@ -243,6 +245,7 @@
             <td><span class="status-badge todo">{{ sprint.status }}</span></td>
             <td>
               <form method="POST" action="{{ url_for('activate_sprint', sprint_id=sprint.id) }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button type="submit" class="btn btn-sm primary-action-btn">Activate</button>
               </form>
             </td>
@@ -307,6 +310,7 @@
   <div class="modal-dialog modal-lg modal-dialog-centered">
     <div class="modal-content">
       <form method="POST" action="{{ url_for('sprints') }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="modal-header">
           <h5 class="modal-title fw-bold" id="newSprintModalLabel">Create New Sprint</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Werkzeug==3.0.1
 Alembic==1.13.0
 pytest==9.0.3
 selenium==4.43.0
+Flask-WTF==1.2.1


### PR DESCRIPTION
**Description**

This PR adds CSRF protection to the app’s POST forms.

**What was added**

added Flask-WTF as a dependency  
set up CSRFProtect in the Flask app  
added CSRF tokens to login and registration forms  
added CSRF tokens to profile and settings forms  
added CSRF tokens to project create, edit, delete, and assign-user forms  
added CSRF tokens to sprint create, activate, complete, and check-in forms  
added CSRF tokens to task create and edit forms  
enabled CSRF checks after all POST forms were updated  

**Key files changed**

app/__init__.py  
requirements.txt  
app/templates/auth.html  
app/templates/profile.html  
app/templates/settings.html  
app/templates/project.html  
app/templates/project_detail.html  
app/templates/sprints.html  
app/templates/dashboard.html  
app/templates/backlog.html  

**Verification**

/auth renders successfully and includes csrf_token  
POST /auth without a CSRF token returns 400
checked all POST forms include CSRF tokens  

Closes #52