### PR TITLE
Add Selenium tests for core dashboard and sprint flows

### DIFF
--- a/tests/test_selenium_core_flows.py
+++ b/tests/test_selenium_core_flows.py
@@ -16,8 +16,11 @@ from app.models import Project, Sprint, SprintCheckIn, Task, User
 
 
 class SeleniumCoreFlowTestCase(unittest.TestCase):
+    """Selenium coverage for the main authenticated dashboard and sprint flows."""
+
     @classmethod
     def setUpClass(cls):
+        """Start a live Flask server backed by a shared in-memory test database."""
         cls.app = create_app({
             "TESTING": True,
             "SQLALCHEMY_DATABASE_URI": "sqlite://",
@@ -36,6 +39,7 @@ class SeleniumCoreFlowTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        """Stop the live server and release database connections after the suite."""
         cls.server.shutdown()
         cls.server_thread.join(timeout=5)
         with cls.app.app_context():
@@ -43,6 +47,7 @@ class SeleniumCoreFlowTestCase(unittest.TestCase):
             db.engine.dispose()
 
     def setUp(self):
+        """Create fresh browser, user, project, sprint, and task fixtures per test."""
         with self.app.app_context():
             db.drop_all()
             db.create_all()
@@ -100,12 +105,14 @@ class SeleniumCoreFlowTestCase(unittest.TestCase):
         self.wait = WebDriverWait(self.driver, 10)
 
     def tearDown(self):
+        """Close the browser and reset database state after each test."""
         self.driver.quit()
         with self.app.app_context():
             db.session.remove()
             db.drop_all()
 
     def login(self):
+        """Log the seeded Selenium user in through the browser UI."""
         self.driver.get(f"{self.base_url}/auth?mode=login")
         login_form = self.wait.until(
             EC.visibility_of_element_located((By.CSS_SELECTOR, "form[data-auth-form='login']"))
@@ -116,18 +123,21 @@ class SeleniumCoreFlowTestCase(unittest.TestCase):
         self.wait.until(EC.url_contains("/dashboard"))
 
     def test_protected_dashboard_redirects_to_login(self):
+        """Logged-out users should be redirected from the dashboard to login."""
         self.driver.get(f"{self.base_url}/dashboard")
 
         self.wait.until(EC.url_contains("/auth"))
         self.assertIn("mode=login", self.driver.current_url)
 
     def test_login_opens_dashboard(self):
+        """A valid login should land the user on the dashboard."""
         self.login()
 
         self.assertIn("/dashboard", self.driver.current_url)
         self.assertIn("Welcome back, Selenium Core User", self.driver.page_source)
 
     def test_dashboard_shows_live_project_and_task_data(self):
+        """The dashboard should render seeded project, task, and sprint data."""
         self.login()
 
         self.assertIn("Selenium Demo Project", self.driver.page_source)
@@ -135,6 +145,7 @@ class SeleniumCoreFlowTestCase(unittest.TestCase):
         self.assertIn("Selenium Active Sprint", self.driver.page_source)
 
     def test_sprints_page_shows_active_sprint_and_checkin_form(self):
+        """The sprints page should show the active sprint and daily check-in form."""
         self.login()
         self.driver.get(f"{self.base_url}/sprints")
 
@@ -144,6 +155,7 @@ class SeleniumCoreFlowTestCase(unittest.TestCase):
         self.assertTrue(self.driver.find_element(By.ID, "workload_level").is_displayed())
 
     def test_sprint_health_checkin_can_be_submitted_from_browser(self):
+        """Submitting the sprint health form should save and display the check-in."""
         self.login()
         self.driver.get(f"{self.base_url}/sprints")
 

--- a/tests/test_selenium_core_flows.py
+++ b/tests/test_selenium_core_flows.py
@@ -1,0 +1,116 @@
+import threading
+import unittest
+from datetime import date, timedelta
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+from sqlalchemy.pool import StaticPool
+from werkzeug.security import generate_password_hash
+from werkzeug.serving import make_server
+
+from app import create_app, db
+from app.models import Project, Sprint, Task, User
+
+
+class SeleniumCoreFlowTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = create_app({
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": "sqlite://",
+            "SQLALCHEMY_ENGINE_OPTIONS": {
+                "connect_args": {"check_same_thread": False},
+                "poolclass": StaticPool,
+            },
+            "WTF_CSRF_ENABLED": False,
+        })
+
+        cls.server = make_server("127.0.0.1", 0, cls.app)
+        cls.base_url = f"http://127.0.0.1:{cls.server.server_port}"
+        cls.server_thread = threading.Thread(target=cls.server.serve_forever)
+        cls.server_thread.daemon = True
+        cls.server_thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server_thread.join(timeout=5)
+        with cls.app.app_context():
+            db.session.remove()
+            db.engine.dispose()
+
+    def setUp(self):
+        with self.app.app_context():
+            db.drop_all()
+            db.create_all()
+
+            self.user = User(
+                full_name="Selenium Core User",
+                email="selenium-core@test.com",
+                password_hash=generate_password_hash("password123"),
+            )
+            self.project = Project(
+                name="Selenium Demo Project",
+                description="Project used by Selenium flow tests.",
+                status="active",
+                health_status="healthy",
+            )
+            db.session.add_all([self.user, self.project])
+            db.session.commit()
+
+            self.sprint = Sprint(
+                project_id=self.project.id,
+                name="Selenium Active Sprint",
+                goal="Check the main browser workflow.",
+                status="active",
+                start_date=date.today(),
+                end_date=date.today() + timedelta(days=10),
+                total_story_points=20,
+                completed_story_points=5,
+                velocity_points=5,
+            )
+            db.session.add(self.sprint)
+            db.session.commit()
+
+            task = Task(
+                project_id=self.project.id,
+                sprint_id=self.sprint.id,
+                assignee_id=self.user.id,
+                created_by=self.user.id,
+                title="Selenium assigned task",
+                status="in_progress",
+                story_points=3,
+                due_date=date.today() + timedelta(days=2),
+            )
+            db.session.add(task)
+            db.session.commit()
+
+            self.user_id = self.user.id
+            self.sprint_id = self.sprint.id
+
+        options = Options()
+        options.add_argument("--headless")
+        options.add_argument("--no-sandbox")
+        options.add_argument("--disable-dev-shm-usage")
+        options.add_argument("--window-size=1440,1000")
+        self.driver = webdriver.Chrome(options=options)
+        self.wait = WebDriverWait(self.driver, 10)
+
+    def tearDown(self):
+        self.driver.quit()
+        with self.app.app_context():
+            db.session.remove()
+            db.drop_all()
+
+    def test_protected_dashboard_redirects_to_login(self):
+        self.driver.get(f"{self.base_url}/dashboard")
+
+        self.wait.until(EC.url_contains("/auth"))
+        self.assertIn("mode=login", self.driver.current_url)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_selenium_core_flows.py
+++ b/tests/test_selenium_core_flows.py
@@ -105,11 +105,34 @@ class SeleniumCoreFlowTestCase(unittest.TestCase):
             db.session.remove()
             db.drop_all()
 
+    def login(self):
+        self.driver.get(f"{self.base_url}/auth?mode=login")
+        login_form = self.wait.until(
+            EC.visibility_of_element_located((By.CSS_SELECTOR, "form[data-auth-form='login']"))
+        )
+        login_form.find_element(By.NAME, "email").send_keys("selenium-core@test.com")
+        login_form.find_element(By.NAME, "password").send_keys("password123")
+        login_form.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+        self.wait.until(EC.url_contains("/dashboard"))
+
     def test_protected_dashboard_redirects_to_login(self):
         self.driver.get(f"{self.base_url}/dashboard")
 
         self.wait.until(EC.url_contains("/auth"))
         self.assertIn("mode=login", self.driver.current_url)
+
+    def test_login_opens_dashboard(self):
+        self.login()
+
+        self.assertIn("/dashboard", self.driver.current_url)
+        self.assertIn("Welcome back, Selenium Core User", self.driver.page_source)
+
+    def test_dashboard_shows_live_project_and_task_data(self):
+        self.login()
+
+        self.assertIn("Selenium Demo Project", self.driver.page_source)
+        self.assertIn("Selenium assigned task", self.driver.page_source)
+        self.assertIn("Selenium Active Sprint", self.driver.page_source)
 
 
 if __name__ == "__main__":

--- a/tests/test_selenium_core_flows.py
+++ b/tests/test_selenium_core_flows.py
@@ -6,13 +6,13 @@ from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support.ui import Select, WebDriverWait
 from sqlalchemy.pool import StaticPool
 from werkzeug.security import generate_password_hash
 from werkzeug.serving import make_server
 
 from app import create_app, db
-from app.models import Project, Sprint, Task, User
+from app.models import Project, Sprint, SprintCheckIn, Task, User
 
 
 class SeleniumCoreFlowTestCase(unittest.TestCase):
@@ -133,6 +133,42 @@ class SeleniumCoreFlowTestCase(unittest.TestCase):
         self.assertIn("Selenium Demo Project", self.driver.page_source)
         self.assertIn("Selenium assigned task", self.driver.page_source)
         self.assertIn("Selenium Active Sprint", self.driver.page_source)
+
+    def test_sprints_page_shows_active_sprint_and_checkin_form(self):
+        self.login()
+        self.driver.get(f"{self.base_url}/sprints")
+
+        self.wait.until(EC.text_to_be_present_in_element((By.TAG_NAME, "h1"), "Selenium Active Sprint"))
+        self.assertIn("Daily Check-in", self.driver.page_source)
+        self.assertTrue(self.driver.find_element(By.ID, "confidence_level").is_displayed())
+        self.assertTrue(self.driver.find_element(By.ID, "workload_level").is_displayed())
+
+    def test_sprint_health_checkin_can_be_submitted_from_browser(self):
+        self.login()
+        self.driver.get(f"{self.base_url}/sprints")
+
+        Select(self.wait.until(EC.element_to_be_clickable((By.ID, "confidence_level")))).select_by_value("4")
+        Select(self.driver.find_element(By.ID, "workload_level")).select_by_value("2")
+        self.driver.find_element(By.ID, "blockers").send_keys("Browser blocker")
+        needs_help = self.driver.find_element(By.NAME, "needs_help")
+        self.driver.execute_script("arguments[0].click();", needs_help)
+        save_button = self.driver.find_element(By.XPATH, "//button[contains(., 'Save Check-in')]")
+        self.driver.execute_script("arguments[0].click();", save_button)
+
+        self.wait.until(EC.text_to_be_present_in_element((By.ID, "health"), "1 check-in"))
+        self.assertIn("Confidence 4/5", self.driver.page_source)
+        self.assertIn("Workload 2/5", self.driver.page_source)
+        self.assertIn("Browser blocker", self.driver.page_source)
+        self.assertIn("Needs help", self.driver.page_source)
+
+        with self.app.app_context():
+            checkin = SprintCheckIn.query.one()
+            self.assertEqual(checkin.sprint_id, self.sprint_id)
+            self.assertEqual(checkin.user_id, self.user_id)
+            self.assertEqual(checkin.confidence_level, 4)
+            self.assertEqual(checkin.workload_level, 2)
+            self.assertEqual(checkin.blockers, "Browser blocker")
+            self.assertTrue(checkin.needs_help)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description**

This PR adds Selenium browser coverage for the main logged-in dashboard and sprint health workflows.

**What was added**

added a reusable Selenium test setup with a live Flask server
added a protected dashboard redirect test for logged-out users
added login and dashboard browser flow tests
added dashboard checks for live project, task, and sprint data
added sprint page checks for the active sprint and daily check-in form
added a browser test for submitting a sprint health check-in

**Key files changed**

tests/test_selenium_core_flows.py

**Verification**

py -m unittest tests.test_selenium_profile_settings tests.test_selenium_core_flows
- Ran 10 Selenium tests: OK
