### PR TITLE
Fix backlog pagination for filters and project backlogs

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -640,6 +640,18 @@ def create_app(test_config=None):
 
         return task_query, backlog_options
 
+    def build_backlog_pagination_links(pagination, endpoint, **view_args):
+        """Build Previous/Next links while preserving current backlog query options."""
+        def page_url(page_number):
+            query_args = request.args.to_dict(flat=True)
+            query_args["page"] = page_number
+            return url_for(endpoint, **view_args, **query_args)
+
+        return {
+            "prev": page_url(pagination.prev_num) if pagination.has_prev else None,
+            "next": page_url(pagination.next_num) if pagination.has_next else None,
+        }
+
     @app.route("/projects/<int:project_id>/backlog")
     def project_backlog(project_id):
         if g.user is None:
@@ -764,6 +776,7 @@ def create_app(test_config=None):
         page = request.args.get('page', 1, type=int)
         per_page = 10
         pagination = task_query.paginate(page=page, per_page=per_page, error_out=False)
+        pagination_links = build_backlog_pagination_links(pagination, "backlog")
         tasks = pagination.items
 
         projects = Project.query.filter_by(status="active").order_by(Project.name.asc()).all()
@@ -780,7 +793,9 @@ def create_app(test_config=None):
             search_query=search_query,
             total_task_count=total_task_count,
             total_unassigned_count=total_unassigned_count,
-            backlog_options=backlog_options,pagination=pagination,
+            backlog_options=backlog_options,
+            pagination=pagination,
+            pagination_links=pagination_links,
             assignee_options=assignee_options
         )
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -673,7 +673,15 @@ def create_app(test_config=None):
         )
         task_query = apply_backlog_search(base_task_query, search_query)
         task_query, backlog_options = apply_backlog_options(task_query)
-        tasks = task_query.all()
+        page = request.args.get("page", 1, type=int)
+        per_page = 10
+        pagination = task_query.paginate(page=page, per_page=per_page, error_out=False)
+        pagination_links = build_backlog_pagination_links(
+            pagination,
+            "project_backlog",
+            project_id=project.id
+        )
+        tasks = pagination.items
 
         users = User.query.filter_by(is_active=True)\
             .order_by(User.full_name.asc())\
@@ -693,6 +701,8 @@ def create_app(test_config=None):
             total_task_count=total_task_count,
             total_unassigned_count=total_unassigned_count,
             backlog_options=backlog_options,
+            pagination=pagination,
+            pagination_links=pagination_links,
             assignee_options=assignee_options
         )
     

--- a/app/static/css/backlog_styles.css
+++ b/app/static/css/backlog_styles.css
@@ -481,6 +481,18 @@
   color: #ffffff;
 }
 
+.page-btn-disabled {
+  color: #9ca3af;
+  cursor: not-allowed;
+  background-color: #f9fafb;
+}
+
+.page-btn-current {
+  color: #0f4c5c;
+  background-color: #eef6f5;
+  border-color: #d7ebe8;
+}
+
 /* Page footer */
 .backlog-footer {
   display: flex;

--- a/app/templates/backlog.html
+++ b/app/templates/backlog.html
@@ -339,8 +339,19 @@
     </span>
     <div class="pagination-btns">
       {% if pagination and pagination.pages > 1 %}
-      <a href="?page={{ pagination.prev_num }}" class="page-btn {% if not pagination.has_prev %}disabled{% endif %}">Previous</a>
-      <a href="?page={{ pagination.next_num }}" class="page-btn page-btn-active {% if not pagination.has_next %}disabled{% endif %}">Next</a>
+        {% if pagination_links.prev %}
+        <a href="{{ pagination_links.prev }}" class="page-btn">Previous</a>
+        {% else %}
+        <span class="page-btn page-btn-disabled" aria-disabled="true">Previous</span>
+        {% endif %}
+
+        <span class="page-btn page-btn-current">Page {{ pagination.page }} of {{ pagination.pages }}</span>
+
+        {% if pagination_links.next %}
+        <a href="{{ pagination_links.next }}" class="page-btn page-btn-active">Next</a>
+        {% else %}
+        <span class="page-btn page-btn-disabled" aria-disabled="true">Next</span>
+        {% endif %}
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
**Description**

This PR fixes the remaining backlog pagination issues.

**What was added**

preserved search, filter, assignee, and sort options when using backlog pagination
added disabled pagination states and a current page label
added pagination to the project backlog route so it no longer loads all project tasks at once

**Key files changed**

app/__init__.py
app/templates/backlog.html
app/static/css/backlog_styles.css

**Verification**

py -m unittest tests.test_profile_settings
- Ran 6 tests: OK

Backlog pagination smoke check passed for global and project backlog links.
