### PR TITLE
Add Settings Password Change Flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ server-*.log
 agilepm.db
 *.db
 *.db-journal
+*.db-wal
+*.db-shm
 
 # Uploaded profile images
 app/static/uploads/*

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1013,6 +1013,32 @@ def create_app(test_config=None):
                 flash('Settings saved successfully.', 'success')
                 return redirect(url_for('settings'))
 
+            if action == 'change_password':
+                current_password = request.form.get('current_password', '')
+                new_password = request.form.get('new_password', '')
+                confirm_password = request.form.get('confirm_password', '')
+
+                if not check_password_hash(g.user.password_hash, current_password):
+                    flash('Current password is incorrect.', 'danger')
+                    return redirect(url_for('settings'))
+
+                if len(new_password) < 6:
+                    flash('New password must be at least 6 characters.', 'danger')
+                    return redirect(url_for('settings'))
+
+                if new_password != confirm_password:
+                    flash('New passwords do not match.', 'danger')
+                    return redirect(url_for('settings'))
+
+                if check_password_hash(g.user.password_hash, new_password):
+                    flash('New password must be different from your current password.', 'danger')
+                    return redirect(url_for('settings'))
+
+                g.user.password_hash = generate_password_hash(new_password)
+                db.session.commit()
+                flash('Password updated successfully.', 'success')
+                return redirect(url_for('settings'))
+
 
         return render_template('settings.html')
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,7 +2,7 @@ import re
 from datetime import date, datetime
 
 import os
-from sqlalchemy import case, func, or_
+from sqlalchemy import case, event, func, or_
 from werkzeug.utils import secure_filename
 from flask import Flask, app, flash, g, redirect, render_template, request, session, url_for
 from flask_sqlalchemy import SQLAlchemy
@@ -31,6 +31,15 @@ def create_app(test_config=None):
 
     # Initialize extensions
     db.init_app(app)
+
+    if app.config["SQLALCHEMY_DATABASE_URI"].startswith("sqlite"):
+        with app.app_context():
+            @event.listens_for(db.engine, "connect")
+            def set_sqlite_journal_mode(dbapi_connection, connection_record):
+                cursor = dbapi_connection.cursor()
+                cursor.execute("PRAGMA journal_mode=PERSIST")
+                cursor.close()
+
     migrate.init_app(app, db)
     csrf.init_app(app)
 

--- a/app/static/css/settings.css
+++ b/app/static/css/settings.css
@@ -252,6 +252,15 @@
     box-shadow: 0 0 0 3px rgba(29, 158, 117, 0.12);
 }
 
+.password-grid {
+    align-items: end;
+}
+
+.password-action-cell {
+    display: flex;
+    justify-content: flex-end;
+}
+
 /* ── Sections 3 & 4 side by side ── */
 .security-notification-grid {
     display: grid;
@@ -458,4 +467,47 @@
 
 #settings-form .settings-action-bar {
     margin-top: 20px;   
+}
+
+@media (max-width: 992px) {
+    .info-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .password-action-cell {
+        justify-content: flex-start;
+    }
+}
+
+@media (max-width: 640px) {
+    .settings-body {
+        padding: 18px 16px;
+    }
+
+    .settings-card {
+        padding: 18px;
+    }
+
+    .account-display {
+        align-items: flex-start;
+        flex-wrap: wrap;
+    }
+
+    .btn-upload {
+        margin-left: 0;
+    }
+
+    .info-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .settings-action-bar {
+        flex-direction: column;
+    }
+
+    .btn-save,
+    .btn-logout-bar {
+        justify-content: center;
+        width: 100%;
+    }
 }

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -123,6 +123,42 @@
             </div>
 
         </form>
+
+        <form method="POST" action="{{ url_for('settings') }}" id="password-form">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <input type="hidden" name="action" value="change_password">
+
+            <div class="settings-card">
+                <div class="settings-section-heading">
+                    <span class="settings-section-number">3</span>
+                    Security
+                </div>
+                <div class="info-grid password-grid">
+                    <div>
+                        <label class="form-label-settings" for="current-password">Current Password</label>
+                        <input type="password" id="current-password" name="current_password"
+                               class="form-input-settings" autocomplete="current-password" required>
+                    </div>
+                    <div>
+                        <label class="form-label-settings" for="new-password">New Password</label>
+                        <input type="password" id="new-password" name="new_password"
+                               class="form-input-settings" autocomplete="new-password"
+                               minlength="6" required>
+                    </div>
+                    <div>
+                        <label class="form-label-settings" for="confirm-password">Confirm Password</label>
+                        <input type="password" id="confirm-password" name="confirm_password"
+                               class="form-input-settings" autocomplete="new-password"
+                               minlength="6" required>
+                    </div>
+                    <div class="password-action-cell">
+                        <button type="submit" class="btn-save">
+                            Change Password
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </form>
     </div>
 </div>
 

--- a/tests/test_profile_settings.py
+++ b/tests/test_profile_settings.py
@@ -1,7 +1,7 @@
 import unittest
 from app import create_app, db
 from app.models import User
-from werkzeug.security import generate_password_hash
+from werkzeug.security import check_password_hash, generate_password_hash
 
 
 class MeihuiTestCase(unittest.TestCase):
@@ -82,6 +82,57 @@ class MeihuiTestCase(unittest.TestCase):
             'email': 'test@test.com',
         }, follow_redirects=True)
         self.assertEqual(response.status_code, 200)
+
+    def test_settings_change_password_success(self):
+        """Settings should update password when current password is correct"""
+        self.login()
+        response = self.client.post('/settings', data={
+            'action': 'change_password',
+            'current_password': 'password123',
+            'new_password': 'newpassword123',
+            'confirm_password': 'newpassword123'
+        }, follow_redirects=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Password updated successfully', response.data)
+
+        with self.app.app_context():
+            user = User.query.filter_by(email='test@test.com').first()
+            self.assertTrue(check_password_hash(user.password_hash, 'newpassword123'))
+
+    def test_settings_change_password_wrong_current_rejected(self):
+        """Settings should reject password changes with wrong current password"""
+        self.login()
+        response = self.client.post('/settings', data={
+            'action': 'change_password',
+            'current_password': 'wrong-password',
+            'new_password': 'newpassword123',
+            'confirm_password': 'newpassword123'
+        }, follow_redirects=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Current password is incorrect', response.data)
+
+        with self.app.app_context():
+            user = User.query.filter_by(email='test@test.com').first()
+            self.assertTrue(check_password_hash(user.password_hash, 'password123'))
+
+    def test_settings_change_password_mismatch_rejected(self):
+        """Settings should reject password confirmation mismatches"""
+        self.login()
+        response = self.client.post('/settings', data={
+            'action': 'change_password',
+            'current_password': 'password123',
+            'new_password': 'newpassword123',
+            'confirm_password': 'different123'
+        }, follow_redirects=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'New passwords do not match', response.data)
+
+        with self.app.app_context():
+            user = User.query.filter_by(email='test@test.com').first()
+            self.assertTrue(check_password_hash(user.password_hash, 'password123'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description**

This PR adds an authenticated password change workflow to the Settings page and fixes a local SQLite journal issue that caused password updates to fail in synced folders.

**What was added**

added a Change Password form to the Settings page  
added backend validation for current password, password length, password confirmation, and password reuse  
updated stored passwords using Werkzeug password hashing  
added unit tests for successful and rejected password changes  
set SQLite to use persistent journal mode to avoid local disk I/O errors  
updated `.gitignore` for SQLite sidecar files  

**Key files changed**

app/__init__.py  
app/templates/settings.html  
app/static/css/settings.css  
tests/test_profile_settings.py  
.gitignore  

**Testing**
Tested Password change works successfully